### PR TITLE
Allow normalization setting to work

### DIFF
--- a/js/VizSettings.js
+++ b/js/VizSettings.js
@@ -405,7 +405,7 @@ function vizSettingsWidget(node, callback, vizState, dsID, hide) {
 				}, //no normalization
 				{
 					"value": "subset",
-					"text": "normalize",
+					"text": "across selected samples",
 					"index": 1
 				} //selected sample level
 

--- a/js/appSelector.js
+++ b/js/appSelector.js
@@ -42,7 +42,7 @@ var transformSelector = createFmapSelector(
 		state => _.fmap(state.columns,
 			(column, key) => [
 				column,
-				_.getIn(state, ['vizSettings', state.dsID]),
+				_.getIn(state, ['vizSettings', column.dsID]),
 				state.data[key],
 				state.samples,
 				state.datasets.datasets[column.dsID],


### PR DESCRIPTION
Issue https://github.com/ucscXena/ucsc-xena-client/issues/38
`dsID` parameter was not available on the state, but instead within the applicable column (which sits on the state).  This is how the dsID was obtained, when providing props to the VizSettings component during initial load of the application.