### PR TITLE
Close tool tip outside of Columns

### DIFF
--- a/js/Crosshair.js
+++ b/js/Crosshair.js
@@ -13,12 +13,19 @@ require('../css/crosshairs.css');
 var Crosshair = React.createClass({
 	mixins: [deepPureRenderMixin], // XXX any reason to use deep vs. shallow?
 	getDefaultProps: function() {
-		return {
-			point: { x: 0, y: 0 }
+		return {point: { x: 0, y: 0 }}
+	},
+	getInitialState: function() {
+		return {point: this.props.point};
+	},
+	componentWillReceiveProps: function(newProps) {
+		if (!newProps.frozen){
+			this.setState({point: newProps.point})
 		}
 	},
 	render: function () {
-		let { point: {x, y}, open, dims } = this.props,
+		var {open, dims } = this.props,
+			{point: {x, y}} = this.state,
 			containerStyle = _.extend({display: open ? 'inline' : 'none'}, dims);
 		return (
 			<div className='crosshairs' style={containerStyle}>

--- a/js/plotMutationVector.js
+++ b/js/plotMutationVector.js
@@ -151,7 +151,7 @@ var MutationColumn = hotOrNot(React.createClass({
 	},
 	onDownload: function() {
 		const SAMPLE_ID_FIELD = 'sample';
-		let {data: {req: {rows}}, samples, index} = this.props,
+		var {data: {req: {rows}}, samples, index} = this.props,
 			groupedSamples = _.getIn(index, ['bySample']) || [],
 			rowFields = getRowFields(rows, groupedSamples, SAMPLE_ID_FIELD),
 			allRows = _.map(samples, (sId) => {
@@ -164,7 +164,7 @@ var MutationColumn = hotOrNot(React.createClass({
 
 	onMuPit: function () {
 		// Construct the url, which will be opened in new window
-		let rows = _.getIn(this.props, ['data', 'req', 'rows']),
+		var rows = _.getIn(this.props, ['data', 'req', 'rows']),
 			uriList = _.uniq(_.map(rows, n => `${n.chr}:${n.start.toString()}`)).join(','),
 			url = `http://mupit.icm.jhu.edu/?gm=${uriList}`;
 

--- a/js/plotMutationVector.js
+++ b/js/plotMutationVector.js
@@ -175,7 +175,8 @@ var MutationColumn = hotOrNot(React.createClass({
 		return tooltip(nodes, samples, zoom, fields[0], assembly, ev);
 	},
 	render: function () {
-		var {column, samples, zoom, data, index, disableKM} = this.props,
+		var {column, disableKM, data, hasSurvival, id, index, onClick, samples, zoom} = this.props,
+			{mousemove, mouseout, mouseover} = this.ev,
 			feature = _.getIn(column, ['sFeature']),
 			assembly = _.getIn(column, ['assembly']),
 			rightAssembly = (assembly === "hg19" || assembly === "GRCh37") ? true : false,  //MuPIT currently only support hg19
@@ -187,8 +188,9 @@ var MutationColumn = hotOrNot(React.createClass({
 		return (
 			<Column
 				callback={this.props.callback}
-				id={this.props.id}
 				disableKM={disableKM}
+				id={id}
+				hasSurvival={hasSurvival}
 				download={this.onDownload} //eslint-disable-line no-undef
 				column={column}
 				zoom={zoom}
@@ -199,10 +201,10 @@ var MutationColumn = hotOrNot(React.createClass({
 						draw={drawMutations}
 						wrapperProps={{
 							className: 'Tooltip-target',
-							onMouseMove: this.ev.mousemove,
-							onMouseOut: this.ev.mouseout,
-							onMouseOver: this.ev.mouseover,
-							onClick: this.props.onClick
+							onMouseMove: mousemove,
+							onMouseOut: mouseout,
+							onMouseOver: mouseover,
+							onClick: onClick
 						}}
 						feature={feature}
 						nodes={column.nodes}


### PR DESCRIPTION
Issue https://github.com/ucscXena/ucsc-xena-client/issues/45

Sorry for the late PR.  One of the problems I ran into had to do with the 'unfreezing' event listener not being removed from the 'body' element.  I originally registered an anonymous function for the unfreezing, instead of a callback (separate method).  But, I also setup the process of adding and removing the event listener as a dynamic process, i.e. when user tries to freeze crosshairs, the event listener would be added to the body element, and when unfreezing, the event listener would be removed.

In the end, I registered the listener in `componentDidMount`, and removed it in `componentWillUnmount`
*** Don't merge until you respond with an 'okay'; so I can squash the commits.