### PR TITLE
assembly aware branch put assembly into column state object, and pull…

### DIFF
--- a/css/tooltip.css
+++ b/css/tooltip.css
@@ -33,3 +33,6 @@
 	float:right;
 	padding-left: 4px;
 }
+.Tooltip a {
+	text-decoration: underline;
+}

--- a/js/ColumnEdit.js
+++ b/js/ColumnEdit.js
@@ -126,7 +126,7 @@ var GeneProbeEdit = React.createClass({
 			<div>
         {this.props.genes ?
   				<div className='form-group'>
-  					<label className='col-md-2 control-label'>Input:</label>			
+  					<label className='col-md-2 control-label'>Input:</label>
   						<div className='col-md-4'>
   							<Input onChange={() => this.setState({genes: true})}
   								 checked={genes}
@@ -173,11 +173,11 @@ var ColumnEdit = React.createClass({
 	addColumn: function (settings) {
 		let {callback, appState: {datasets}} = this.props,
 			label = datasets[this.state.dataset].label,
-      assembly = datasets[this.state.dataset].assembly;
+			assembly = datasets[this.state.dataset].assembly;
 			settings = _.assoc(settings,
 				'width', 200, // XXX move this default setting?
 				'columnLabel', {user: label, 'default': label},
-        'assembly', assembly,
+				'assembly', assembly,
 				'dsID', this.state.dataset);
 		this.props.onHide();
 		callback(['add-column', uuid(), settings]);

--- a/js/ColumnEdit.js
+++ b/js/ColumnEdit.js
@@ -172,10 +172,12 @@ var ColumnEdit = React.createClass({
 	getInitialState: () => ({}),
 	addColumn: function (settings) {
 		let {callback, appState: {datasets}} = this.props,
-			label = datasets[this.state.dataset].label;
+			label = datasets[this.state.dataset].label,
+      assembly = datasets[this.state.dataset].assembly;
 			settings = _.assoc(settings,
 				'width', 200, // XXX move this default setting?
 				'columnLabel', {user: label, 'default': label},
+        'assembly', assembly,
 				'dsID', this.state.dataset);
 		this.props.onHide();
 		callback(['add-column', uuid(), settings]);

--- a/js/DatasetSelect.js
+++ b/js/DatasetSelect.js
@@ -18,10 +18,10 @@ var sortByLabel = list => _.sortBy(list, el => el.label.toLowerCase());
 
 
 
-function optsFromDatasets(servers) {
-	return _.flatmap(servers, (datasets, server) => {
+function optsFromDatasets(dataSubTypes) {
+	return _.flatmap(dataSubTypes, (datasets, dataSubType) => {
 		let sortedOpts = sortByLabel(filterDatasets(datasets)).map(d => ({value: d.dsID, label: d.label}));
-		return [{label: header(server), header: true}].concat(sortedOpts);
+		return [{label: dataSubType, header: true}].concat(sortedOpts);
 	});
 }
 
@@ -30,7 +30,7 @@ var DatasetSelect = React.createClass({
 	render: function () {
 		var {datasets, nullOpt, ...other} = this.props,
 			options = (nullOpt ? [{value: null, label: nullOpt}] : [])
-				.concat(optsFromDatasets(_.groupBy(datasets, 'server')))
+				.concat(optsFromDatasets(_.groupBy(datasets, 'dataSubType')))
 
 		return (
 			<Select {...other}  options={options} />

--- a/js/models/mutationVector.js
+++ b/js/models/mutationVector.js
@@ -176,12 +176,12 @@ function cmp({fields}, data, index) {
 var sparseDataValues = xenaQuery.dsID_fn(xenaQuery.sparse_data_values);
 var refGeneExonValues = xenaQuery.dsID_fn(xenaQuery.refGene_exon_values);
 
-// support for hg18/CRCh36, hg19/CRCh37 
+// support for hg18/CRCh36, hg19/CRCh37
 var refGene = {
-  hg18: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg18'}),
-  GRCh36: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg18'}),
-  hg19: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg19'}),
-  GRCh37: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg19'})
+	hg18: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg18'}),
+	GRCh36: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg18'}),
+	hg19: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg19'}),
+	GRCh37: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg19'})
 }
 
 function fetch({dsID, fields, assembly}, samples) {
@@ -235,10 +235,10 @@ function dataToDisplay({width, fields, sFeature, xzoom = {index: 0}},
 	}
 	var {refGene} = data;
 
-  if (_.isEmpty(refGene)){
-    return {};
-  }
-  
+	if (_.isEmpty(refGene)){
+		return {};
+	}
+
 	var layout = exonLayout.layout(_.values(refGene)[0], width, xzoom),
 		nodes = findNodes(index.byPosition, layout, sFeature, sortedSamples,
 				zoom);

--- a/js/models/mutationVector.js
+++ b/js/models/mutationVector.js
@@ -176,16 +176,18 @@ function cmp({fields}, data, index) {
 var sparseDataValues = xenaQuery.dsID_fn(xenaQuery.sparse_data_values);
 var refGeneExonValues = xenaQuery.dsID_fn(xenaQuery.refGene_exon_values);
 
-// XXX hard-coded for now
-var refGene = JSON.stringify({
-	host: "https://genome-cancer.ucsc.edu/proj/public/xena",
-	name: "common/GB/refgene_good"
-});
+// support for hg18/CRCh36, hg19/CRCh37 
+var refGene = {
+  hg18: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg18'}),
+  GRCh36: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg18'}),
+  hg19: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg19'}),
+  GRCh37: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg19'})
+}
 
-function fetch({dsID, fields}, samples) {
+function fetch({dsID, fields, assembly}, samples) {
 		return Rx.Observable.zipArray(
 			sparseDataValues(dsID, fields[0], samples),
-			refGeneExonValues(refGene, fields)
+			refGene[assembly] ? refGeneExonValues(refGene[assembly], fields): Rx.Observable.return({})
 		).map(resp => _.object(['req', 'refGene'], resp));
 }
 
@@ -232,6 +234,11 @@ function dataToDisplay({width, fields, sFeature, xzoom = {index: 0}},
 		return {};
 	}
 	var {refGene} = data;
+
+  if (_.isEmpty(refGene)){
+    return {};
+  }
+  
 	var layout = exonLayout.layout(_.values(refGene)[0], width, xzoom),
 		nodes = findNodes(index.byPosition, layout, sFeature, sortedSamples,
 				zoom);

--- a/js/plotMutationVector.js
+++ b/js/plotMutationVector.js
@@ -70,8 +70,6 @@ function formatAf(af) {
 }
 
 var fmtIf = (x, fmt) => x ? fmt(x) : '';
-var gbURL = 'http://genome.ucsc.edu/cgi-bin/hgTracks?db=$assembly&position=';
-var assemblyVar = '$assembly';
 var dropNulls = rows => rows.map(row => row.filter(col => col != null)) // drop empty cols
 	.filter(row => row.length > 0); // drop empty rows
 
@@ -80,7 +78,8 @@ function sampleTooltip(data, gene, assembly) {
 		rnaVaf = data.rna_vaf == null ? null : ['labelValue',  'RNA variant allele freq', formatAf(data.rna_vaf)],
 		refAlt = data.reference && data.alt && ['value', `${data.reference} to ${data.alt}`],
 		pos = data && `${data.chr}:${util.addCommas(data.start)}-${util.addCommas(data.end)}`,
-		posURL = ['url',  assembly+ ` ${pos}`, gbURL.replace(assemblyVar, assembly) + encodeURIComponent(pos)],
+		gbURL =  (assembly, pos) => `http://genome.ucsc.edu/cgi-bin/hgTracks?db=${encodeURIComponent(assembly)}&position=${encodeURIComponent(pos)}`,
+		posURL = ['url',  `${assembly} ${pos}`, gbURL],
 		effect = ['value', fmtIf(data.effect, x => `${x}, `) +  gene + //eslint-disable-line comma-spacing
 					fmtIf(data.amino_acid, x => ` (${x})`)];
 
@@ -178,10 +177,10 @@ var MutationColumn = hotOrNot(React.createClass({
 	render: function () {
 		var {column, samples, zoom, data, index, hasSurvival} = this.props,
 			feature = _.getIn(column, ['sFeature']),
-      assembly = _.getIn(column, ['assembly']),
-      rightAssembly = (assembly ==="hg19" || assembly ==="GRCh37") ? true : false,  //MuPIT currently only support hg19
-      gotData = ( data &&  data.req && data.req.rows.length>0 ) ? true : false,
-      noMenu = !rightAssembly || !gotData,  //loadingMenu = data ? false : true,
+			assembly = _.getIn(column, ['assembly']),
+			rightAssembly = (assembly ==="hg19" || assembly ==="GRCh37") ? true : false,  //MuPIT currently only support hg19
+			gotData = ( data &&  data.req && data.req.rows.length>0 ) ? true : false,
+			noMenu = !rightAssembly || !gotData,  //loadingMenu = data ? false : true,
 			menuItemName = 'MuPIT View (hg19)';
 
 		// XXX Make plot a child instead of a prop? There's also legend.

--- a/js/refGeneExons.js
+++ b/js/refGeneExons.js
@@ -33,6 +33,9 @@ var toIntvl = (start, end, i) => ({start: start, end: end, i: i});
 // findIntervals(gene :: {cdsStart :: int, cdsEnd :: int, exonStarts :: [int, ...], exonEnds :: [int, ...]})
 //     :: [{start :: int, end :: int, i :: int, inCds :: boolean}, ...]
 function findIntervals(gene) {
+  if (_.isEmpty(gene)){
+    return [];
+  }
 	var {cdsStart, cdsEnd, exonStarts, exonEnds} = gene;
 
 	return _.map(_.flatmap(_.flatmap(_.zip(exonStarts, exonEnds),
@@ -67,6 +70,9 @@ var RefGeneAnnotation = React.createClass({
 	},
 
 	draw: function (width, layout, indx) {
+    if (!width || !layout ||!indx){
+      return;
+    }
 		var vg = this.vg,
 			ctx = vg.context(),
 			prevEnd;
@@ -106,7 +112,6 @@ var RefGeneAnnotation = React.createClass({
 			intervals = findIntervals(refGene);
 
 		this.index = index(intervals);
-
 		if (this.vg) {
 			this.draw(width, layout, this.index);
 		}

--- a/js/refGeneExons.js
+++ b/js/refGeneExons.js
@@ -33,9 +33,9 @@ var toIntvl = (start, end, i) => ({start: start, end: end, i: i});
 // findIntervals(gene :: {cdsStart :: int, cdsEnd :: int, exonStarts :: [int, ...], exonEnds :: [int, ...]})
 //     :: [{start :: int, end :: int, i :: int, inCds :: boolean}, ...]
 function findIntervals(gene) {
-  if (_.isEmpty(gene)){
-    return [];
-  }
+	if (_.isEmpty(gene)){
+		return [];
+	}
 	var {cdsStart, cdsEnd, exonStarts, exonEnds} = gene;
 
 	return _.map(_.flatmap(_.flatmap(_.zip(exonStarts, exonEnds),
@@ -70,9 +70,9 @@ var RefGeneAnnotation = React.createClass({
 	},
 
 	draw: function (width, layout, indx) {
-    if (!width || !layout ||!indx){
-      return;
-    }
+		if (!width || !layout ||!indx){
+			return;
+		}
 		var vg = this.vg,
 			ctx = vg.context(),
 			prevEnd;

--- a/js/xenaQuery.js
+++ b/js/xenaQuery.js
@@ -370,7 +370,7 @@ define(['rx-dom', './underscore_ext', 'rx.binding'], function (Rx, _) {
 	function dataset_list_new(server, cohort) {
 		return Rx.DOM.ajax(
 			xena_post(server, dataset_list_query(cohort))
-		).map(resp => xena_dataset_list_transform(server, json_resp(resp)));
+		).map(resp => xena_dataset_list_transform(server, json_resp(resp))).catch(Rx.Observable.return([]));
 	}
 
 	function dataset_list(server, cohort) {
@@ -556,7 +556,7 @@ define(['rx-dom', './underscore_ext', 'rx.binding'], function (Rx, _) {
 	function all_samples(host, cohort) {
 		return Rx.DOM.ajax(
 			xena_post(host, all_samples_query(cohort))
-		).map(json_resp);
+		).map(json_resp).catch(Rx.Observable.return([]));
 	}
 
 	// XXX Have to use POST here because the genome-cancer reverse proxy fails
@@ -565,7 +565,7 @@ define(['rx-dom', './underscore_ext', 'rx.binding'], function (Rx, _) {
 	function all_cohorts(host) {
 		return Rx.DOM.ajax(
 			xena_post(host, all_cohorts_query())
-		).map(json_resp);
+		).map(json_resp).catch(Rx.Observable.return([]));
 	}
 
 	// test if host is up

--- a/js/xenaQuery.js
+++ b/js/xenaQuery.js
@@ -370,7 +370,7 @@ define(['rx-dom', './underscore_ext', 'rx.binding'], function (Rx, _) {
 	function dataset_list_new(server, cohort) {
 		return Rx.DOM.ajax(
 			xena_post(server, dataset_list_query(cohort))
-		).map(resp => xena_dataset_list_transform(server, json_resp(resp))).catch(Rx.Observable.return([]));
+		).map(resp => xena_dataset_list_transform(server, json_resp(resp)));
 	}
 
 	function dataset_list(server, cohort) {
@@ -556,7 +556,7 @@ define(['rx-dom', './underscore_ext', 'rx.binding'], function (Rx, _) {
 	function all_samples(host, cohort) {
 		return Rx.DOM.ajax(
 			xena_post(host, all_samples_query(cohort))
-		).map(json_resp).catch(Rx.Observable.return([]));
+		).map(json_resp);
 	}
 
 	// XXX Have to use POST here because the genome-cancer reverse proxy fails
@@ -565,7 +565,7 @@ define(['rx-dom', './underscore_ext', 'rx.binding'], function (Rx, _) {
 	function all_cohorts(host) {
 		return Rx.DOM.ajax(
 			xena_post(host, all_cohorts_query())
-		).map(json_resp).catch(Rx.Observable.return([]));
+		).map(json_resp);
 	}
 
 	// test if host is up


### PR DESCRIPTION
… refgene, show tooltip, show mulpit linkout accordingly

**Not sure the fix in js/refGeneExons.js is OK. **    the branch also handle the situation when no assembly or no supported assembly, or bogou gene name situation, in all cases, no gene annotation can be requested -- no browser crash --- not sure if the fix is ok.
  
xenaQuery handles host is not active situation for all_cohorts, all_samples and dataset_list functions.