### PR TITLE
add functionality to support drawing of SV (using existing mutationVe…

### DIFF
--- a/js/chart.js
+++ b/js/chart.js
@@ -1,10 +1,9 @@
 /*eslint strict: [2, "function"], camelcase: 0, no-use-before-define: 0 */
 /*eslint-env browser */
-/*jshint browser: true, onevar: true */
 /*global define: false, document: false */
+'use strict';
 define(['./xenaQuery', './dom_helper', './colorScales', './highcharts', './highcharts_helper', './underscore_ext', 'rx'],
 	function (xenaQuery, dom_helper, colorScales, highcharts, highcharts_helper, _, Rx) {
-	'use strict';
 	var Highcharts = highcharts.Highcharts;
 
 	var custom_colors ={};

--- a/js/drawMutations.js
+++ b/js/drawMutations.js
@@ -53,16 +53,19 @@ function drawImpactPx(vg, width, pixPerRow, color, variants, strand) {
 
 			// structrual variants (SV) have follow vcf https://samtools.github.io/hts-specs/VCFv4.2.pdf
 			// "[" and "]" in alt means these are SV variants
-			if (v.data.alt[0].search(/[\[\]]/)!==-1 && strand ==="+") {
+			var firstBase = v.data.alt[0],
+				lastBase = v.data.alt[v.data.alt.length-1];
+
+			if ((firstBase ==='[' || firstBase===']') && strand === '+') {
 				//SV: new segment to the left
 				return [0, v.y, v.xEnd + padding, v.y];
-			} else if (v.data.alt[0].search(/[\[\]]/)!==-1 && strand ==="-") {
+			} else if ((firstBase ==='[' || firstBase===']') && strand === '-') {
 				//SV: new segment to the left, right in transcript space
 				return [v.xStart - padding, v.y, width + padding, v.y];
-			} else if (v.data.alt[v.data.alt.length-1].search(/[\[\]]/)!==-1 && strand ==="+") {
+			} else if ((lastBase ==='[' || lastBase===']') && strand === '+') {
 				//SV: new segment on the right
 				return [v.xStart - padding, v.y, width + padding, v.y];
-			} else if (v.data.alt[v.data.alt.length-1].search(/[\[\]]/)!==-1 && strand ==="-") {
+			} else if ((lastBase ==='[' || lastBase===']') && strand === '-') {
 				//SV: new segment on the right, left in transcript space
 				return [0, v.y, v.xEnd + padding, v.y];
 			} else {

--- a/js/drawMutations.js
+++ b/js/drawMutations.js
@@ -44,40 +44,57 @@ function drawBackground(vg, width, height, pixPerRow, hasValue) {
 	vg.drawRectangles(rects, {fillStyle: 'grey'});
 }
 
-function drawImpactPx(vg, width, pixPerRow, color, variants) {
+function drawImpactPx(vg, width, pixPerRow, color, variants, strand) {
 	var varByImp = groupByConsec(variants, v => v.group);
 
 	_.each(varByImp, vars => {
-
 		var points = vars.map(v => {
 			var padding = Math.max(0, radius - (v.xEnd - v.xStart + 1) / 2.0);
-			return [v.xStart - padding, v.y, v.xEnd + padding, v.y];
+
+			// structrual variants (SV) have follow vcf https://samtools.github.io/hts-specs/VCFv4.2.pdf
+			// "[" and "]" in alt means these are SV variants
+			if (v.data.alt[0].search(/[\[\]]/)!==-1 && strand ==="+") {
+				//SV: new segment to the left
+				return [0, v.y, v.xEnd + padding, v.y];
+			} else if (v.data.alt[0].search(/[\[\]]/)!==-1 && strand ==="-") {
+				//SV: new segment to the left, right in transcript space
+				return [v.xStart - padding, v.y, width + padding, v.y];
+			} else if (v.data.alt[v.data.alt.length-1].search(/[\[\]]/)!==-1 && strand ==="+") {
+				//SV: new segment on the right
+				return [v.xStart - padding, v.y, width + padding, v.y];
+			} else if (v.data.alt[v.data.alt.length-1].search(/[\[\]]/)!==-1 && strand ==="-") {
+				//SV: new segment on the right, left in transcript space
+				return [0, v.y, v.xEnd + padding, v.y];
+			} else {
+				// small indels or SNVs
+ 				return [v.xStart - padding, v.y, v.xEnd + padding, v.y];
+			}
 		});
 		vg.drawPoly(points,
-			{strokeStyle: color(vars[0].group), lineWidth: pixPerRow})
+			{strokeStyle: color(vars[0].group), lineWidth: pixPerRow});
 
 		if (pixPerRow > 2) { // centers when there is enough vertical room for each sample
-			let points = vars.map(v => [v.xStart, v.y, v.xEnd, v.y]);
+			points = vars.map(v => [v.xStart, v.y, v.xEnd, v.y]);
 			vg.drawPoly(points,
-				{strokeStyle: 'black', lineWidth: pixPerRow / 8});
-
+				{strokeStyle: 'black', lineWidth: pixPerRow});
 		}
 	});
 }
 
 function drawMutations(vg, props) {
-	let {width, zoom: {count, height, index}, nodes} = props;
+	let {width, strand, zoom: {count, height, index}, nodes} = props;
 	if (!nodes) {
 		vg.box(0, 0, width, height, "gray");
 		return;
 	}
+
 	let {feature, samples, index: {bySample: samplesInDS}} = props,
 		pixPerRow = height / count,
 		minppr = Math.max(pixPerRow, 2),
 		hasValue = samples.slice(index, index + count).map(s => samplesInDS[s]);
 
 	drawBackground(vg, width, height, pixPerRow, hasValue);
-	drawImpactPx(vg, width, minppr, features[feature].color, nodes);
+	drawImpactPx(vg, width, minppr, features[feature].color, nodes, strand);
 }
 
 module.exports = {drawMutations, radius};

--- a/js/exonLayout.js
+++ b/js/exonLayout.js
@@ -56,10 +56,10 @@ function pxLen(chrlo) {
 // Layout exons on screen pixels.
 // layout(genepred :: {exonStarts : [<int>, ...], exonEnds: [<int>, ...], strand: <string>)
 //  :: {chrom: [[<int>, <int>], ...], screen: [[<int>, <int>], ...], reversed: <boolean>}
-// XXX promoter region?
-function layout({exonStarts, exonEnds, strand}, pxWidth, zoom) {
-	var padding = 200, // extra bp on the ends of transcripts
-		chrIntvls = reverseIf(strand, padBothEnds(pad(spLen, _.zip(exonStarts, exonEnds)), padding)),
+// padding: promoter region, and region after end of gene padding=0 is just showing the gene
+// startExonIndex, endExonIndex : used to specify which exon range to show 0,1 for first exon, 0, 2 for 1st and 2nd exon
+function layout({exonStarts, exonEnds, strand}, pxWidth, zoom, padding, startExon, endExon) {
+	var chrIntvls = reverseIf(strand, padBothEnds(pad(spLen, _.zip(exonStarts, exonEnds)), padding)).slice(startExon, endExon),
 		count = _.getIn(zoom, ['len'], baseLen(chrIntvls)),
 		bpp = count / pxWidth,
 		pixIntvls = toScreen(bpp, chrIntvls, 0, []);

--- a/js/highcharts_helper.js
+++ b/js/highcharts_helper.js
@@ -1,10 +1,9 @@
 /*eslint strict: [2, "function"], camelcase: 0 */
 /*global define: true*/
+'use strict';
 define(['./highcharts'], function () {
-  'use strict';
-
   function hcLabelRender(){
-	/*jshint -W040 */ // Due to the way highcharts is configured.
+	///*jshint -W040 */ // Due to the way highcharts is configured.
     var s = this.name;
     var r = "";
     var lastAppended = 0;

--- a/js/models/mutationVector.js
+++ b/js/models/mutationVector.js
@@ -78,7 +78,7 @@ var unknownEffect = 0,
 	},
 	colorStr = c =>
 		'rgba(' + c.r + ', ' + c.g + ', ' + c.b + ', ' + c.a.toString() + ')',
-	saveUndef = f => v => v === null ? v : f(v),
+	saveUndef = f => v => v == null ? v : f(v),
 	round = Math.round,
 	decimateFreq = saveUndef(v => round(v * 31) / 32), // reduce to 32 vals
 
@@ -88,10 +88,11 @@ var unknownEffect = 0,
 		labels: ['0%', '50%', '100%'],
 		align: 'center'
 	},
+
 	features = {
 		impact: {
 			get: (a, v) => impact[v.effect] || (v.effect ? unknownEffect : undefined),
-			color: v => colorStr(v === null ? colors.grey : colors.category4[v]),
+			color: v => colorStr(v == null ? colors.grey : colors.category4[v]),
 			legend: {
 				colors: colors.category4.map(colorStr),
 				labels: _.range(_.keys(impactGroups).length).map(
@@ -100,13 +101,13 @@ var unknownEffect = 0,
 			}
 		},
 		'dna_vaf': {
-			get: (a, v) => v.dna_vaf === null ? undefined : decimateFreq(v.dna_vaf),
-			color: v => colorStr(v === null ? colors.grey : _.assoc(colors.af, 'a', v)),
+			get: (a, v) => v.dna_vaf == null ? undefined : decimateFreq(v.dna_vaf),
+			color: v => colorStr(v == null ? colors.grey : _.assoc(colors.af, 'a', v)),
 			legend: vafLegend
 		},
 		'rna_vaf': {
-			get: (a, v) => v.rna_vaf === null ? undefined : decimateFreq(v.rna_vaf),
-			color: v => colorStr(v === null ? colors.grey : _.assoc(colors.af, 'a', v)),
+			get: (a, v) => v.rna_vaf == null ? undefined : decimateFreq(v.rna_vaf),
+			color: v => colorStr(v == null ? colors.grey : _.assoc(colors.af, 'a', v)),
 			legend: vafLegend
 		}
 	};
@@ -156,10 +157,10 @@ function cmpRowOrNoVariants(v1, v2, refGene) {
 }
 
 function cmpRowOrNull(v1, v2, refGene) {
-	if (v1 === null) {
-		return (v2 === null) ? 0 : 1;
+	if (v1 == null) {
+		return (v2 == null) ? 0 : 1;
 	}
-	return (v2 === null) ? -1 : cmpRowOrNoVariants(v1, v2, refGene);
+	return (v2 == null) ? -1 : cmpRowOrNoVariants(v1, v2, refGene);
 }
 
 function cmpSamples(probes, sample, refGene, s1, s2) {

--- a/js/models/mutationVector.js
+++ b/js/models/mutationVector.js
@@ -59,12 +59,12 @@ var unknownEffect = 0,
 		'stop_retained_variant': 1,
 
 		//mutations outside the exon region and splice region get organge color, code =0
+		'others': 0,
+		'SV':0,
 		'upstream_gene_variant': 0,
 		'downstream_gene_variant': 0,
 		'intron_variant': 0,
 		'intergenic_region': 0,
-
-		"others": 0
 	},
 	colors = {
 		category4: [
@@ -241,13 +241,19 @@ function dataToDisplay({width, fields, sFeature, xzoom = {index: 0}},
 	if (_.isEmpty(refGene)){
 		return {};
 	}
+	console.log(vizSettings);
+	var refGeneObj = _.values(refGene)[0],
+		padding = 200, // extra bp on both ends of transcripts
+		startExon = 0,
+		endExon = refGeneObj.exonCount,
+		strand = refGeneObj.strand,
+		layout = exonLayout.layout(refGeneObj, width, xzoom, padding, startExon, endExon),
+		nodes = findNodes(index.byPosition, layout, sFeature, sortedSamples, zoom);
 
-	var layout = exonLayout.layout(_.values(refGene)[0], width, xzoom),
-		nodes = findNodes(index.byPosition, layout, sFeature, sortedSamples,
-				zoom);
 	return {
 		layout,
-		nodes
+		nodes,
+		strand
 	};
 }
 

--- a/js/models/mutationVector.js
+++ b/js/models/mutationVector.js
@@ -78,7 +78,7 @@ var unknownEffect = 0,
 	},
 	colorStr = c =>
 		'rgba(' + c.r + ', ' + c.g + ', ' + c.b + ', ' + c.a.toString() + ')',
-	saveUndef = f => v => v == null ? v : f(v),
+	saveUndef = f => v => v === null ? v : f(v),
 	round = Math.round,
 	decimateFreq = saveUndef(v => round(v * 31) / 32), // reduce to 32 vals
 
@@ -91,7 +91,7 @@ var unknownEffect = 0,
 	features = {
 		impact: {
 			get: (a, v) => impact[v.effect] || (v.effect ? unknownEffect : undefined),
-			color: v => colorStr(v == null ? colors.grey : colors.category4[v]),
+			color: v => colorStr(v === null ? colors.grey : colors.category4[v]),
 			legend: {
 				colors: colors.category4.map(colorStr),
 				labels: _.range(_.keys(impactGroups).length).map(
@@ -100,13 +100,13 @@ var unknownEffect = 0,
 			}
 		},
 		'dna_vaf': {
-			get: (a, v) => v.dna_vaf == null ? undefined : decimateFreq(v.dna_vaf),
-			color: v => colorStr(v == null ? colors.grey : _.assoc(colors.af, 'a', v)),
+			get: (a, v) => v.dna_vaf === null ? undefined : decimateFreq(v.dna_vaf),
+			color: v => colorStr(v === null ? colors.grey : _.assoc(colors.af, 'a', v)),
 			legend: vafLegend
 		},
 		'rna_vaf': {
-			get: (a, v) => v.rna_vaf == null ? undefined : decimateFreq(v.rna_vaf),
-			color: v => colorStr(v == null ? colors.grey : _.assoc(colors.af, 'a', v)),
+			get: (a, v) => v.rna_vaf === null ? undefined : decimateFreq(v.rna_vaf),
+			color: v => colorStr(v === null ? colors.grey : _.assoc(colors.af, 'a', v)),
 			legend: vafLegend
 		}
 	};
@@ -156,10 +156,10 @@ function cmpRowOrNoVariants(v1, v2, refGene) {
 }
 
 function cmpRowOrNull(v1, v2, refGene) {
-	if (v1 == null) {
-		return (v2 == null) ? 0 : 1;
+	if (v1 === null) {
+		return (v2 === null) ? 0 : 1;
 	}
-	return (v2 == null) ? -1 : cmpRowOrNoVariants(v1, v2, refGene);
+	return (v2 === null) ? -1 : cmpRowOrNoVariants(v1, v2, refGene);
 }
 
 function cmpSamples(probes, sample, refGene, s1, s2) {
@@ -185,7 +185,7 @@ var refGene = {
 	GRCh36: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg18'}),
 	hg19: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg19'}),
 	GRCh37: JSON.stringify({host: 'https://reference.xenahubs.net', name: 'refgene_good_hg19'})
-}
+};
 
 function fetch({dsID, fields, assembly}, samples) {
 		return Rx.Observable.zipArray(
@@ -241,7 +241,6 @@ function dataToDisplay({width, fields, sFeature, xzoom = {index: 0}},
 	if (_.isEmpty(refGene)){
 		return {};
 	}
-	console.log(vizSettings);
 	var refGeneObj = _.values(refGene)[0],
 		padding = 200, // extra bp on both ends of transcripts
 		startExon = 0,

--- a/js/plotMutationVector.js
+++ b/js/plotMutationVector.js
@@ -206,6 +206,7 @@ var MutationColumn = hotOrNot(React.createClass({
 						}}
 						feature={feature}
 						nodes={column.nodes}
+						strand={column.strand}
 						width={column.width}
 						data={data}
 						index={index}


### PR DESCRIPTION
1. support drawing of SV (structural variants) using mutation vector drawing with minor modifications). 
![image](https://cloud.githubusercontent.com/assets/999493/14310206/86d06048-fb95-11e5-819e-2765d0aa97f3.png)

2. support dynamically specify the padding on each end of gene and which exons (e.g. exon 0-1, 0-2) to show.  However, not sure where is a good place to provide UI input these specifications on padding and startExon, endExon.

