### PR TITLE
Fixed issue#93

### DIFF
--- a/js/plotDenseMatrix.js
+++ b/js/plotDenseMatrix.js
@@ -69,15 +69,16 @@ function tooltip(heatmap, assembly, fields, sampleFormat, fieldFormat, codes, po
 		label = fieldFormat(field);
 
 	val = code ? code : prec(val);
-
+	let mean = prec(_.meannull(heatmap[fieldIndex]));
+	let median = prec(_.medianNull(heatmap[fieldIndex]));
 	return {
 		sampleID: sampleFormat(sampleID),
 		rows: [
 			[['labelValue', label, val]],
 			...(pos && assembly ? [[['url', `${assembly} ${posString(pos)}`, gbURL(assembly, pos)]]] : []),
-			...(val !== 'NA' && !code ?
-				[[['labelValue', 'Mean (Median)', prec(_.meannull(heatmap[fieldIndex])) + ' (' +
-				 prec(_.medianNull(heatmap[fieldIndex])) + ')' ]]] : [])]
+			...(!code && (mean !== 'NA') && (median !== 'NA')) ?
+				[[['labelValue', 'Mean (Median)', mean + ' (' +
+				 median + ')' ]]] : []]
 	};
 }
 


### PR DESCRIPTION
@acthp I have created a fix to handle even when the whole column is null and tested it (sharing screens) 

**# Complete column is Null**

![null complete](https://user-images.githubusercontent.com/5182674/36635150-fb3c8276-19d5-11e8-92a3-018b89f5c6ea.png)

**# Complete column is not Null, but selecting null area**

![null value](https://user-images.githubusercontent.com/5182674/36635098-6222b290-19d5-11e8-867a-02764140a2d4.png)

**#Complete column is not Null and selecting non-null area**

![non null value](https://user-images.githubusercontent.com/5182674/36635109-7ac9caa4-19d5-11e8-8af2-b87e1d8d6bc2.png)

