### PR TITLE
Optimize Bookmark Nav

### DIFF
--- a/js/views/BookmarkMenu.module.css
+++ b/js/views/BookmarkMenu.module.css
@@ -4,6 +4,7 @@
 	margin-left: 4px;
 	/* Using !important, because I can't out why the css ordering is wrong */
 	z-index: 1060 !important; /* in front of KmPlot dialog */
+	margin-top: 30px; /* let the menu do not overlay the "bookmark" icon */
 }
 
 


### PR DESCRIPTION
In this PR, I optimize the Bookmark Nav. When I am developing other parts of the UI, I found that when I click the bookmark nav, the pop nav will overlay the "BookMark" button, I feel a little wired of this UX. So I move it a little bit lower. I hope this change will give users better UX.

The original look:
<img width="750" alt="original" src="https://user-images.githubusercontent.com/7977100/37152997-1f9607a6-2290-11e8-949b-bbf96fa265fb.png">

The new look:
<img width="750" alt="new" src="https://user-images.githubusercontent.com/7977100/37153008-26ab20f8-2290-11e8-91ac-335171a66682.png">

If the pop nav need further optimize, I can continue working on it.

Thanks.