### PR TITLE
Fix stateError overlay #199

### DIFF
--- a/js/StateError.js
+++ b/js/StateError.js
@@ -7,6 +7,11 @@ import Dialog from 'react-toolbox/lib/dialog';
 
 var StateError = React.createClass({
 	mixins: [deepPureRenderMixin],
+
+	componentDidMount: function() {
+		var body = document.getElementById("body");
+		body.style.overflow = "auto";
+	},
 	render() {
 
 		const actions = [
@@ -24,7 +29,10 @@ var StateError = React.createClass({
 					title='Whoops...'
 					className={stateErrorStyle.dialog}
 					onEscKeyDown={this.props.onHide}
-					onOverlayClick={this.props.onHide}>
+					onOverlayClick={this.props.onHide}
+					theme={{
+						wrapper: stateErrorStyle.dialogWrapper,
+						overlay: stateErrorStyle.dialogOverlay}}>
 					<p>We were unable to restore the view from your {this.props.error}, possibly due to software
 						updates. Sorry about that!</p>
 				</Dialog>

--- a/js/StateError.module.css
+++ b/js/StateError.module.css
@@ -15,4 +15,20 @@ button.dialogClose > i {
 
 .dialog {
 	padding-top: 10px;
+	width: 500px;
+	margin-left: calc((100% - 500px) / 2);
+	margin-top: 150px;
+}
+
+.dialogWrapper {
+	display: block;
+	position: absolute;
+	height: calc(100% - 179px);
+	top: 64px;
+}
+
+.dialogOverlay {
+	position: absolute;
+	height: 100%;
+	top: 0;
 }


### PR DESCRIPTION
The first edition of StateError will overlay the navbar and footer, sorry for not notice this, this PR, optimize the StateError, do the following changes to StateError:

1. StateError will not overlay the navbar and footer
2. The body of page become scrollable
3. Adjust the length of StateError to have a more fancy UI

New StateError screen shot:
<img width="750" alt="new" src="https://user-images.githubusercontent.com/7977100/37236353-6f7a4ba2-23bb-11e8-8cf4-e4d0a1c9ee79.png">

Old StateError screen shot:
<img width="750" alt="old" src="https://user-images.githubusercontent.com/7977100/37236354-732d550a-23bb-11e8-8c9f-fcd379b1520b.png">

The change to StateError is the same as the last change to kmPlot.js, I will pay attention to this overlay problem when I refactor other part of views in the future. @acthp 
Thanks.
