### PR TITLE
Fixed Phenotype search problem on pressing return

### DIFF
--- a/js/views/VariableSelect.js
+++ b/js/views/VariableSelect.js
@@ -351,11 +351,11 @@ class VariableSelect extends PureComponent {
 		var {features} = this.props,
 			{basicFeatures, value, mode} = this.state,
 			i = (featureIn ? features.indexOf(featureIn) : _.findIndex(features, _.matcher({label: value[mode]}))).toString();
-		if (i) {
+		if (i !== "-1") {
 			this.setState({basicFeatures: _.uniq([...basicFeatures, i])});
 			this.on.select({selectValue: i, isOn: true});
-			this.on.field("");
 		}
+		this.on.field("");
 	};
 
 	render() {


### PR DESCRIPTION
the onAddFeature function, for a random search having no match in the 'features' the value of i is -1.

When this.setState was called inside the if statement,an error features[-1] is undefined occured which stopped the execution of code this.on.field("").