### PR TITLE
Enhance dialog to scroll page to top

### DIFF
--- a/js/KmPlot.js
+++ b/js/KmPlot.js
@@ -161,6 +161,7 @@ class WarningTrigger extends React.Component {
 
 class WarningDialog extends React.Component {
 	componentDidMount() {
+		document.documentElement.scrollTop = 0;
 		var body = document.getElementById("body");
 		body.style.overflow = "auto";
 	}
@@ -354,6 +355,7 @@ class KmPlot extends PureComponent {
 	};
 
 	componentDidMount() {
+		document.documentElement.scrollTop = 0;
 		var body = document.getElementById("body");
 		body.style.overflow = "auto";
 	}

--- a/js/StateError.js
+++ b/js/StateError.js
@@ -7,6 +7,7 @@ import Dialog from 'react-toolbox/lib/dialog';
 
 class StateError extends PureComponent {
 	componentDidMount() {
+		document.documentElement.scrollTop = 0;
 		var body = document.getElementById("body");
 		body.style.overflow = "auto";
 	}

--- a/js/views/VizSettings.js
+++ b/js/views/VizSettings.js
@@ -623,6 +623,7 @@ class SettingsWrapper extends React.Component {
 class VizSettings extends React.Component {
 
 	componentDidMount() {
+		document.documentElement.scrollTop = 0;
 		var body = document.getElementById("body");
 		body.style.overflow = "auto";
 	}


### PR DESCRIPTION
In this PR, I enhance the UX of dialog. In the previous version, when opening a dialog, for example, KM plot, if the page has already been scrolled down a lot, client window may show only part of the dialog. I fix it to let the page scroll to top when dialog did mount. Now user can always see narbar and full dialog in the window after dialog rendered.

I did this kind of change to all dialogs, I hope this change can enhance the UX, looking forward for your review and suggestions. @acthp 

Screen shot of the situation which may happens before:
<img width="750" alt="before" src="https://user-images.githubusercontent.com/7977100/37823911-352b8424-2e48-11e8-80e3-1d8e35d44aa7.png">

Screen shot of the dialog now, always show narbar at the top of client window:
<img width="750" alt="now" src="https://user-images.githubusercontent.com/7977100/37823922-3de21312-2e48-11e8-93e4-40836fbaf9ba.png">