### PR TITLE
Rewrite vizsettings in normal react code

### DIFF
--- a/js/underscore_ext.js
+++ b/js/underscore_ext.js
@@ -402,6 +402,11 @@ function imap(arr, fn) {
 		})
 	};
 }
+
+function valToStr(v) {
+	return (!isNaN(v) && (v !== null) && (v !== undefined)) ? "" + v : "";
+}
+
 //
 //function* irange(n) {
 //	for (let i = 0; i < n; ++i) {
@@ -456,6 +461,7 @@ _.mixin({
 	unique,
 	uniquify,
 	withoutIndex,
+	valToStr,
 	// This inscrutable method allows one to write a 'let' expression via
 	// es6 default arguments, e.g. _.Let((x = 5, y = x + 2) => x + y) === 12
 	Let: f => f()


### PR DESCRIPTION
As vizsettings was originally plain javascript, in this PR, I rewrite part of vizsettings in a more "normal react" way. The changes I did are listed below:

1. Rename React class to uppercase(the original lower case can not be used as &lt;XXX /&gt;)
2. Write new React classes to replace original static dom functions
3. Replace document.createElement() with native react class tag
4. Move util function valToStr to underscore_ext.js
5. Organize all utils functions in a inner object settingUtils (In this way, it will be easier for us to organize these kind of logics in future, not scattered in different parts)
6. Delete useless img import

Looking forward for your review and suggestions. @acthp 

Thanks.