### PR TITLE
Replace glyphicon with material icon

### DIFF
--- a/js/KmPlot.js
+++ b/js/KmPlot.js
@@ -151,7 +151,7 @@ class WarningTrigger extends React.Component {
 					onClick={() => this.setState({show: true})}
 					className={kmStyle.showPWarningButton}
 				>
-					<span className={`glyphicon glyphicon-warning-sign ${kmStyle.pWarningIcon}`}/>
+					<i className={`material-icons ${kmStyle.pWarningIcon}`}>warning</i>
 				</Button>
 				{this.state.show ? <WarningDialog onHide={this.close} header={header} body={body}/> : null}
 			</div>
@@ -383,12 +383,12 @@ class KmPlot extends PureComponent {
 						data.</h3></div>
 					: <div>
 						<Button onClick={this.pdf} className={kmStyle.PDFButton}>
-							<span className={`glyphicon glyphicon-download ${kmStyle.buttonIcon}`}/>
-							PDF
+							<i className={`material-icons ${kmStyle.buttonIcon}`}>file_download</i>
+							<span className={kmStyle.buttonText}>PDF</span>
 						</Button>
 						<Button onClick={this.help} className={kmStyle.helpButton}>
-							<span className={`glyphicon glyphicon-question-sign ${kmStyle.buttonIcon}`}/>
-							Help
+							<i className={`material-icons ${kmStyle.buttonIcon}`}>help</i>
+							<span className={kmStyle.buttonText}>Help</span>
 						</Button>
 						{makeGraph(groups, this.setActiveLabel, activeLabel, sectionDims.graph)}
 						{makeDefinitions(groups, this.setActiveLabel, activeLabel, sectionDims.definitions, maySplit, splits, this.onSplits)}

--- a/js/km.module.css
+++ b/js/km.module.css
@@ -143,11 +143,16 @@ div.warningDialog {
     margin-top: 200px;
 }
 
-.buttonIcon {
+i.buttonIcon {
     margin-right: 10px;
-    margin-top: -2px;
+    margin-top: 10px;
     box-sizing: border-box;
     font-size: 18px;
+}
+
+.buttonText {
+    display: inline-block;
+    margin-top: -10px;
 }
 
 .PDFButton {
@@ -161,6 +166,7 @@ div.warningDialog {
 .pWarningIcon {
     color: #8d0000;
     float: left;
+    font-size: 18px;
 }
 
 .showPWarningButton {

--- a/js/views/Column.js
+++ b/js/views/Column.js
@@ -269,12 +269,11 @@ function getStatusView(status, onReload) {
 	if (status === 'error') {
 		return (
 			<div style={styles.status}>
-				<span
-					onClick={onReload}
-					title='Error loading data. Click to reload.'
-					style={styles.error}
-					className='glyphicon glyphicon-warning-sign'
-					aria-hidden='true'/>
+				<i onClick={onReload}
+				   style={styles.error}
+				   title='Error loading data. Click to reload.'
+				   aria-hidden='true'
+				   className={'material-icons'}>warning</i>
 			</div>);
 	}
 	return null;


### PR DESCRIPTION
In this PR, I replace all glyphicon with material icon, and adjust the css to fix UI problem caused by using material icon.

The reason I do this change is that the glyphicon is bootstrap icon, when we remove the bootstrap css from the project, the glyphicon we use before will not show. This PR is preparing for remove bootstrap css from main.js.

Use kmPlot for example, when remove bootstrap css, the icon will not show, the screen shot is as shown below:
<img width="750" alt="old" src="https://user-images.githubusercontent.com/7977100/37922839-8ce7f296-30e2-11e8-844d-23ddf0d85777.png">

The screen shot of the kmPlot now (after remove bootstrap):
<img width="750" alt="new" src="https://user-images.githubusercontent.com/7977100/37922908-b7ee34a0-30e2-11e8-8d06-6a921748c521.png">

Looking forward for your review and suggestions. @acthp 

