### PR TITLE
Fix table overflow parent node in datapage

### DIFF
--- a/js/Datapages.module.css
+++ b/js/Datapages.module.css
@@ -106,6 +106,7 @@
 .dataSnippetTable {
 	border-collapse:collapse;
 	width: 100%;
+	table-layout: fixed;
 }
 
 .dataSnippetTable tr td {
@@ -114,8 +115,6 @@
 	word-wrap: break-word;
 	color: #505050;
 	font-size: 85%;
-	max-width: 100px;
-	min-width: 30px;
 }
 
 .list {


### PR DESCRIPTION
In this PR, I fix the table layout in "DataPage", for example, when we choose the "Treehouse public expression dataset (July 2017)" and then choose "Expected_count" Hub, we will see the table overflow the right side of parent node, as the screen shot shows below:
<img width="750" alt="before" src="https://user-images.githubusercontent.com/7977100/38046351-5855cc36-3274-11e8-8d80-5e171104daca.png">

The table will not overflow the parent node after this fix, the UI now is as shown below:
<img width="750" alt="after" src="https://user-images.githubusercontent.com/7977100/38046395-733320e4-3274-11e8-9e29-56dae7d3024d.png">

Looking forward for your review and suggestions. @acthp 