### PR TITLE
Optimize welcome to fit the small size client window

### DIFF
--- a/js/views/Welcome.js
+++ b/js/views/Welcome.js
@@ -42,19 +42,19 @@ class Welcome extends Component {
 					<h1 className={typStyles.mdHeadline}>Welcome to the Xena Functional Genomics Explorer</h1>
 					<h2 className={typStyles.mdSubhead}>UCSC Xena allows users to explore functional genomic data sets
 						for correlations between genomic and/or phenotypic variables.</h2>
-					<h2 className={typStyles.mdSubhead}>View live example: <a {...linkProps} href={link}
+					<h2 className={`${compStyles.example} ${typStyles.mdSubhead}`}>View live example: <a {...linkProps} href={link}
 																			   target='_blank'>{text}</a></h2>
-					<div className={compStyles.bulletWrapper}>
-						<div className={compStyles.bullets}>
-							{times(count, j => <div
-													key={j}
-													data-index={j}
-													{...bulletProps}
-													className={i === j ? compStyles.bulletActive : compStyles.bullet}>
+				</div>
+				<div className={compStyles.bulletWrapper}>
+					<div className={compStyles.bullets}>
+						{times(count, j => <div
+							key={j}
+							data-index={j}
+							{...bulletProps}
+							className={i === j ? compStyles.bulletActive : compStyles.bullet}>
 
-													{'\u2022'}
-												</div>)}
-						</div>
+							{'\u2022'}
+						</div>)}
 					</div>
 				</div>
 				<div className={compStyles.closeIcon} onClick={this.dismissWelcome}>

--- a/js/views/Welcome.module.css
+++ b/js/views/Welcome.module.css
@@ -19,7 +19,7 @@
 }
 
 .welcomeText {
-	margin: 48px 0;
+	margin: 30px 0 48px 0;
 	padding-left: 24px;
 	padding-right: 24px;
 	position: relative;
@@ -31,16 +31,19 @@
 	text-decoration: underline;
 }
 
+.example {
+	height: 48px;
+}
+
 .bulletWrapper {
 	position: absolute;
-	left: 50%;
 	bottom: 0;
+	left: 35%;
 }
 
 .bullets {
 	display: inline-block;
 	position: relative;
-	left: -50%;
 	cursor: default;
 }
 
@@ -75,8 +78,8 @@
 	}
 
 	.welcomeText {
+		margin: 48px 0 48px 32px;
 		align-self: center;
-		margin-left: 32px;
 		width: 58.33333333%; /* lg 7 */
 	}
 
@@ -99,6 +102,10 @@
 	.closeIcon {
 		right: 24px;
 		top: 24px;
+	}
+
+	.bulletWrapper {
+		left: 57%;
 	}
 }
 


### PR DESCRIPTION
In this PR, I optimize the welcome part in small client window.

The welcome part looks a little weird when in small window size (<1280px) in previous version, I fix them in this PR. The changes I did are listed below:
1. Fix bullets overlay the example links bug
2. Normalize the height, in the previous version, when ninth bullet are hovered, the height will changes

The screen shots of previous welcome version:
<img width="862" alt="2018-03-30 4 44 51" src="https://user-images.githubusercontent.com/7977100/38157384-51c7af38-343b-11e8-9f93-d491a8e56bc2.png">

<img width="863" alt="2018-03-30 4 44 38" src="https://user-images.githubusercontent.com/7977100/38157390-5e45c010-343b-11e8-8a90-1cd258ff59c6.png">

The screen shot of welcome after this PR:
<img width="952" alt="2018-03-30 4 43 38" src="https://user-images.githubusercontent.com/7977100/38157402-728fb562-343b-11e8-9a09-eb2466f268d7.png">

Hope this PR will enhance the UI of ucsc-xena-client, looking forward for your review and suggestions. @acthp 