### PR TITLE
Fix link style to prepare for removing bootstrap

### DIFF
--- a/css/typography.css
+++ b/css/typography.css
@@ -12,13 +12,28 @@
  */
 
 a {
+	color: #337ab7;
 	text-decoration: none;
 	font-weight: 400;
+	background-color: transparent;
 	-webkit-transition: border-bottom 0.35s;
 	-moz-transition: border-bottom 0.35s;
 	-ms-transition: border-bottom 0.35s;
 	-o-transition: border-bottom 0.35s;
 	transition: border-bottom 0.35s;
+}
+
+a:hover,
+a:focus {
+	outline: 0;
+	color: #23527c;
+	text-decoration: underline;
+}
+
+a:focus {
+	outline: thin dotted;
+	outline: 5px auto -webkit-focus-ring-color;
+	outline-offset: -2px;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/js/views/Welcome.module.css
+++ b/js/views/Welcome.module.css
@@ -31,6 +31,11 @@
 	text-decoration: underline;
 }
 
+.welcomeText a:hover,
+.welcomeText a:focus {
+	color: white;
+}
+
 .bulletWrapper {
 	position: absolute;
 	left: 50%;


### PR DESCRIPTION
In this PR, I add some link styles, with these style definition, the links will not be influence by removing bootstrap.

If we remove the bootstrap now, the link style will be influenced as shown below:
<img width="750" alt="remove" src="https://user-images.githubusercontent.com/7977100/38392394-35df1176-38dc-11e8-9ab9-976784791946.png">

The changes in this PR ensure that the links will now be influenced by removing bootstrap, and can work well with bootstrap now:
<img width="1330" alt="same" src="https://user-images.githubusercontent.com/7977100/38392397-3ac109ec-38dc-11e8-9920-0539f159a5e4.png">

Looking forward for your review and suggestions. @acthp 
