### PR TITLE
Add form style for chart view for removing bootstrap

### DIFF
--- a/js/chart.js
+++ b/js/chart.js
@@ -81,7 +81,7 @@ function render(root, callback, sessionStorage) {
 
 		dropDownDiv = document.createElement("select");
 		dropDownDiv.setAttribute("id", "ynormalization");
-		dropDownDiv.setAttribute("class", "form-control");
+		dropDownDiv.setAttribute("class", compStyles.formControl);
 
 		dropDown.map(function (obj) {
 			option = document.createElement('option');
@@ -122,7 +122,7 @@ function render(root, callback, sessionStorage) {
 
 		dropDownDiv = document.createElement("select");
 		dropDownDiv.setAttribute("id", "yExponentiation");
-		dropDownDiv.setAttribute("class", "form-control");
+		dropDownDiv.setAttribute("class", compStyles.formControl);
 
 		dropDown.map(function (obj) {
 			option = document.createElement('option');
@@ -163,7 +163,7 @@ function render(root, callback, sessionStorage) {
 
 		dropDownDiv = document.createElement("select");
 		dropDownDiv.setAttribute("id", "xExponentiation");
-		dropDownDiv.setAttribute("class", "form-control");
+		dropDownDiv.setAttribute("class", compStyles.formControl);
 
 		dropDown.map(function (obj) {
 			option = document.createElement('option');
@@ -255,7 +255,7 @@ function render(root, callback, sessionStorage) {
 
 		div = document.createElement("select");
 		div.setAttribute("id", selectorID);
-		div.className = "form-control";//"btn btn-default dropdown-toggle";
+		div.className = compStyles.formControl;//"btn btn-default dropdown-toggle";
 
 		// color dropdown add none option at the top
 		if (selectorID === "Color") {

--- a/js/chart.module.css
+++ b/js/chart.module.css
@@ -61,3 +61,58 @@
 .stats.visible {
 	display: block;
 }
+
+/**
+ * Add formControl to ensure the chart view will not be influenced by removing Bootstrap.
+ * In nature, it is a workaround to keep the chart view unchanged.
+ * In future, we can use the React-toolbox widget to replace the basic input component.
+ */
+
+.formControl {
+	display: block;
+	width: 100%;
+	height: 34px;
+	padding: 6px 12px;
+	font-size: 14px;
+	line-height: 1.42857143;
+	color: #555;
+	background-color: #fff;
+	background-image: none;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	-webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+	box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+	-webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+	-o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+	transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+}
+
+.formControl:focus {
+	border-color: #66afe9;
+	outline: 0;
+	-webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, .6);
+	box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, .6);
+}
+
+.formControl::-moz-placeholder {
+	color: #999;
+	opacity: 1;
+}
+
+.formControl:-ms-input-placeholder {
+	color: #999;
+}
+
+.formControl::-webkit-input-placeholder {
+	color: #999;
+}
+
+.formControl[disabled],
+.formControl[readonly] {
+	background-color: #eee;
+	opacity: 1;
+}
+
+.formControl[disabled] {
+	cursor: not-allowed;
+}


### PR DESCRIPTION
In this PR, I add basic styles for form in chart view. This change ensures that the chart view will not be influenced by removing Bootstrap dependencies. The change has backward compatibility, which means that if we do not remove Bootstrap now, it still can work well with the old code.

The screen shot of the influence to chart view after directly removing Bootstrap:
<img width="750" alt="previous" src="https://user-images.githubusercontent.com/7977100/38800239-9f4ff3fe-411b-11e8-8e4f-bc064123537b.png">

After this PR, the chart view can be the same as before:
<img width="750" alt="now" src="https://user-images.githubusercontent.com/7977100/38800260-b0e7da96-411b-11e8-938f-d008336e3d35.png">

Looking forward for your review and suggestions. @acthp 

Thanks.
