### PR TITLE
added a nav link for geneSets - needs feedback

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -47,8 +47,7 @@ var helpLink = {
 };
 
 var geneSetsLink = {
-    // href: 'https://xenageneset.berkeleybop.io/xena/',
-    href: 'http://xenademo.berkeleybop.io/xena/',
+    href: 'https://xenageneset.berkeleybop.io/xena/',
     label: 'Gene Sets',
     target: '_blank'
 };

--- a/js/nav.js
+++ b/js/nav.js
@@ -46,6 +46,13 @@ var helpLink = {
 	target: '_blank'
 };
 
+var geneSetsLink = {
+    // href: 'https://xenageneset.berkeleybop.io/xena/',
+    href: 'http://xenademo.berkeleybop.io/xena/',
+    label: 'Gene Sets',
+    target: '_blank'
+};
+
 var active = (l, activeLink) => l.nav === activeLink;
 
 class XenaNav extends React.Component {
@@ -62,7 +69,8 @@ class XenaNav extends React.Component {
 				<a href='http://xena.ucsc.edu/' className={compStyles.logoXena}><img title={window.ga ? '' : 'no analytics'} src={logoSantaCruzImg} srcSet={logoSrcSet}/></a>
 				<Navigation type="horizontal" routes={routes}>
 					{getState ? <BookmarkMenu isPublic={isPublic} getState={getState} onImport={onImport}/> : null}
-					<Link {...helpLink} />
+					<Link {...geneSetsLink} />
+                    <Link {...helpLink} />
 				</Navigation>
 			</AppBar>
 		);


### PR DESCRIPTION
ATTN: @jingchunzhu  / @acthp 

Related to https://github.com/ucscXena/XenaGoWidget/issues/205

- [x] need to fix cors issue for https://xenageneset.berkeleybop.io/xena/
- [x] need to update the PR to use the production value here (https://github.com/ucscXena/ucsc-xena-client/compare/master...nathandunn:integrate-geneset-viewer?expand=1#diff-031c729d2aefd8d6747defc68bf579d3R51 

Conversely, this is an external link out.  We could also do this internally as its an npm widget, but might need some integration help to make the code more closely align:

https://www.npmjs.com/package/ucsc-xena-geneset
