### PR TITLE
Nav styles provider injection order reverted to last. #520.

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -288,7 +288,7 @@ class XenaNav extends React.Component {
 class ThemedNav extends React.Component {
 	render() {
 		return (
-			<StylesProvider generateClassName={createGenerateClassName({seed: 'Nav'})} injectFirst>
+			<StylesProvider generateClassName={createGenerateClassName({seed: 'Nav'})}>
 				<MuiThemeProvider theme={xenaNavTheme}>
 					<XenaNav {...this.props}/>
 				</MuiThemeProvider>


### PR DESCRIPTION
- The Nav component is rendered after the core Application component. In doing so, the theme provider specific to the Nav component is injected last (after the Application component theme provider).
- To ensure nav-specific theme styles are not overriding core theme styles, a Mui `StylesProvider` component was added to the Nav component with `injectFirst` and `generateClassName` props.
- Unfortunately, by injecting the nav styles first, styles like `.material-icons`, were overriding the nav styles.
- Because the nav styles provider uses a class name generator to namespace the Mui styles, the removal of the `injectFirst` is a suitable solution, because namespacing is sufficient to ensure nav-specific theme styles are not overriding core theme styles.