### PR TITLE
Convert 'Stepper' component to MUI. Bug fix for unconventional use of StepConnector component. #493.

### DIFF
--- a/js/views/Stepper.js
+++ b/js/views/Stepper.js
@@ -18,7 +18,7 @@
 
 
 // Core dependencies, components
-import {AppBar, Box, Step, StepConnector, StepLabel, Stepper as MuiStepper} from '@material-ui/core';
+import {AppBar, Box, Step, StepLabel, Stepper as MuiStepper} from '@material-ui/core';
 var React = require('react');
 var _ = require('../underscore_ext').default;
 import {xenaColor} from '../xenaColor';
@@ -31,6 +31,12 @@ var sxStepperBar = {
 	height: 64,
 	padding: '0 24px',
 };
+var sxStepConnector = {
+	backgroundColor: xenaColor.GRAY_400,
+	flex: 1,
+	height: 1,
+	margin: '0 8px',
+};
 
 class Stepper extends React.Component {
 	render() {
@@ -41,8 +47,12 @@ class Stepper extends React.Component {
 					<MuiStepper activeStep={stateIndex[mode]} connector={null}>
 						{_.map(steps, (step, index) =>
 							<Box component={Step} key={index} sx={{width: wideStep ? '33%' : '25%'}}>
-								<StepLabel>{step.label}</StepLabel>
-								<StepConnector/>
+								<StepLabel>
+									<Box component='span' sx={{alignItems: 'center', display: 'flex'}}>
+										<span>{step.label}</span>
+										<Box component='span' sx={sxStepConnector}/>
+									</Box>
+								</StepLabel>
 							</Box>)}
 					</MuiStepper>
 				</Box>

--- a/js/xenaColor.js
+++ b/js/xenaColor.js
@@ -7,6 +7,7 @@ export const xenaColor = {
 	'BLACK_87': 'rgba(0, 0, 0, 0.87)',
 	'GRAY': '#eee',
 	'GRAY_LIGHT': '#f7f7f7',
+	'GRAY_400': '#bdbdbd',
 	'PRIMARY': '#1a535c',
 	'PRIMARY_CONTRAST': '#ff6b6b',
 	'WARNING': '#8d0000',

--- a/js/xenaTheme.js
+++ b/js/xenaTheme.js
@@ -277,18 +277,6 @@ export const xenaTheme = createTheme(theme, {
 				paddingLeft: 0,
 				paddingRight: 0,
 			},
-			root: {
-				alignItems: 'center',
-				display: 'flex',
-			},
-		},
-		MuiStepConnector: {
-			root: {
-				marginLeft: 8,
-				marginRight: 8,
-				position: 'relative',
-				top: 1,
-			},
 		},
 		MuiStepIcon: {
 			root: {


### PR DESCRIPTION
- Typically the Mui Stepper places an element - a connector line - between each step (see [Mui Stepper](https://v4.mui.com/components/steppers/#horizontal-stepper)).
- The Xena stepper places a connector line after each step (including the last).
- The original solution was to set the `Stepper` prop `connector` to null and insert the component `StepConnector` after each `StepLabel`, however, this generates an error.
- This PR resolves this error by hand-rolling the connector.