### PR TITLE
Gene name labels too narrow for Transcript view. Removed index.css import from Avivator component. #598.

### DIFF
--- a/js/avivator/src/Avivator.jsx
+++ b/js/avivator/src/Avivator.jsx
@@ -8,7 +8,7 @@ import Controller from './components/Controller';
 import DropzoneWrapper from './components/DropzoneWrapper';
 import Footer from './components/Footer';
 
-import './index.css';
+// import './index.css';
 
 /**
  * This component serves as batteries-included visualization for OME-compliant tiff or zarr images.


### PR DESCRIPTION
- CSS import in `Avivator` component commented out. To be resolved at a later date.