### PR TITLE
Added vertical space above the title in charts. #600.

### DIFF
--- a/js/chart/ChartWizard.js
+++ b/js/chart/ChartWizard.js
@@ -100,9 +100,9 @@ var boxOrViolinPage = ({onMode, onDone, onChart, onX, onY, onClose,
 			left: box({sx: {flex: 1}}, button({color: 'default', onClick: onMode, 'data-mode': 'start'}, 'Back')),
 			right: doneButton(isValid(state) && onDone)},
 		box({sx: sxModesContainer}, box({sx: {...sxModes, gap: 8, width: 392}},
-			select({fullWidth: true, label: 'Show data from', onChange: onY,
+			select({SelectProps: {MenuProps: {style: {width: 392}}}, fullWidth: true, label: 'Show data from', onChange: onY,
 					select: true, value: state.ycolumn || ''}, selectOptions(boxOrViolinYDatasets(appState))),
-			select({fullWidth: true, label: 'Subgroup samples by', onChange: onX,
+			select({SelectProps: {MenuProps: {style: {width: 392}}}, fullWidth: true, label: 'Subgroup samples by', onChange: onX,
 				select: true, value: state.xcolumn || ''}, selectOptions(boxOrViolinXDatasets(appState))),
 			needType(state, appState) ?
 				formControl(formLabel('I want a'),
@@ -126,7 +126,7 @@ var histOrDistPage = ({onY, onMode, onDone, onClose, state, props: {appState}}) 
 			left: box({sx: {flex: 1}}, button({color: 'default', onClick: onMode, 'data-mode': 'start'}, 'Back')),
 			right: doneButton(yIsSet(state) && onDone)},
 		box({sx: sxModesContainer}, box({sx: {...sxModes, width: 392}},
-			select({fullWidth: true, label: 'Show data from', onChange: onY,
+			select({SelectProps: {MenuProps: {style: {width: 392}}}, fullWidth: true, label: 'Show data from', onChange: onY,
 				select: true, value: state.ycolumn || ''}, selectOptions(histDatasets(appState))))));
 
 //
@@ -145,9 +145,9 @@ var scatterPage = ({onY, onX, onMode, onDone, onClose, state, props: {appState}}
 			left: box({sx: {flex: 1}}, button({color: 'default', onClick: onMode, 'data-mode': 'start'}, 'Back')),
 			right: doneButton(xyIsSet(state) && onDone)},
 		box({sx: sxModesContainer}, box({sx: {...sxModes, width: 392}},
-			select({fullWidth: true, label: 'Pick the X axis', onChange: onX,
+			select({SelectProps: {MenuProps: {style: {width: 392}}}, fullWidth: true, label: 'Pick the X axis', onChange: onX,
 					select: true, value: state.xcolumn || ''}, selectOptions(scatterXDatasets(appState))),
-			select({fullWidth: true, label: 'Pick the Y axis', onChange: onY,
+			select({SelectProps: {MenuProps: {style: {width: 392}}}, fullWidth: true, label: 'Pick the Y axis', onChange: onY,
 					select: true, value: state.ycolumn || ''}, selectOptions(scatterYDatasets(appState))))));
 
 var noop = () => {};

--- a/js/chart/chart.js
+++ b/js/chart/chart.js
@@ -1265,10 +1265,10 @@ class Chart extends PureComponent {
 		// it in react, or make another wrapper component so react won't touch it.
 		// otoh, since we always re-render, it kinda works as-is.
 
-		return box({mx: 3, my: 12},
+		return box({position: 'relative', mx: 3, my: 12},
 				card({elevation: 2},
-					cardHeader({action: closeButton(this.onClose)}),
 					cardContent(
+						box({sx: {padding: 16, position: 'absolute', right: 0, top: 0}}, closeButton(this.onClose)),
 						box({sx: {display: 'grid', gap: 24, gridTemplateColumns: '1.5fr 1fr', justifyItems: 'flex-start'}},
 						HCV,
 						div({className: compStyles.right},

--- a/js/xenaTheme.js
+++ b/js/xenaTheme.js
@@ -410,6 +410,7 @@ export const xenaTheme = createTheme(theme, {
 				fontSize: 16,
 				paddingBottom: 0,
 				paddingTop: 0,
+				whiteSpace: 'normal',
 				'&:hover': {
 					backgroundColor: xenaColor.GRAY,
 				},


### PR DESCRIPTION
- Remove `cardHeader` and relocated close `x` icon to `cardContent` with position absolute.
- Modified ChartWizard to ensure longer select options wrap.
