### PR TITLE
Disable all column interaction while in wizard or edit mode. #654.

### DIFF
--- a/js/views/ColCard.js
+++ b/js/views/ColCard.js
@@ -45,7 +45,7 @@ class ColCard extends React.Component {
 		var {children, sortable, controls, colId, colMode, interactive, onClick, subtitle,
 			title, geneZoomText, wizardMode, zoomCard} = this.props;
 		return (
-			<Card className={classNames('Column', {[compStyles.zoomCard]: zoomCard})} elevation={2}>
+			<Card className={classNames('Column', {[compStyles.disableInteraction]: !interactive}, {[compStyles.zoomCard]: zoomCard})} elevation={2}>
 				<Box
 					component={CardHeader}
 					action={controls}

--- a/js/views/ColCard.module.css
+++ b/js/views/ColCard.module.css
@@ -22,6 +22,11 @@
 	opacity: 1;
 }
 
+/* Disable column interaction */
+.disableInteraction {
+	pointer-events: none;
+}
+
 /* Container around column label (A, B, C etc) and controls */
 .headerContainer {
 	padding: 16px;

--- a/js/views/Column.js
+++ b/js/views/Column.js
@@ -804,7 +804,7 @@ export default class Column extends PureComponent {
 			chartDisabled = disableChart(column),
 			canDoGeneSetComparison = this.canDoGeneSetComparison(),
       status = _.get(data, 'status'),
-			refreshIcon = (<Box component={IconButton} edge='end' onClick={onReset} sx={{color: xenaColor.GRAY_DARKEST}}><Icon>close</Icon></Box>),
+			refreshIcon = (<Box component={IconButton} edge='end' onClick={onReset} sx={{color: xenaColor.GRAY_DARKEST, pointerEvents: "auto"}}><Icon>close</Icon></Box>),
 			// move this to state to generalize to other annotations.
 			annotation = showPosition(column) ?
 				<RefGeneAnnotation
@@ -849,7 +849,7 @@ export default class Column extends PureComponent {
 					<ZoomOverlay geneHeight={geneHeight()} height={zoom.height}
 								 positionHeight={column.position ? positionHeight : 0} {...dragZoom}>
 						<ColCard colId={label}
-								 interactive={interactive}
+								 interactive={status !== 'loading' && interactive}
 								sortable={!first}
 								title={<DefaultTextInput
 									disabled={!interactive}


### PR DESCRIPTION
- Disables all column interaction while in wizard or edit mode, as well as while card status is "loading".