### PR TITLE
High priority bug fixes recommended by Claude

### DIFF
--- a/js/chart/highchartView.js
+++ b/js/chart/highchartView.js
@@ -816,18 +816,20 @@ function shouldCallDrawChart(prevProps, currentProps) {
 }
 
 class HighchartView extends PureComponent {
+	onResize = () => sizeChartView();
+
 	componentDidMount() {
 		sizeChartView();
 		this.chart = drawChart(this.props.drawProps);
 		this.chart.redraw();
 		this.chart.reflow();
-		window.addEventListener('resize', () => sizeChartView());
+		window.addEventListener('resize', this.onResize);
 	}
 
 	componentWillUnmount() {
 		this.chart?.destroy();
 		this.chart = undefined;
-		window.removeEventListener('resize', () => sizeChartView());
+		window.removeEventListener('resize', this.onResize);
 	}
 
 	componentDidUpdate(prevProps) {

--- a/js/chart/highcharts_helper.js
+++ b/js/chart/highcharts_helper.js
@@ -647,7 +647,7 @@ function renderExpressionMetricsLegend({chart, isSingleCell}) {
 		colorAxis = chart.colorAxis[0],
 		radius = markerScale?.radius;
 	if (!group || !markerScale || !radius) {return;}
-	if (!colorAxis.min || !colorAxis.max) {return;}
+	if (colorAxis.min == null || colorAxis.max == null) {return;}
 
 	// Destroy the expression metrics legend group, if it exists
 	if (chart.legend.exprGroup) {


### PR DESCRIPTION
From Claude:
 1. Event listener leak in HighchartView (highchartView.js:824,829)

 window.addEventListener('resize', () => sizeChartView());  // mount
 window.removeEventListener('resize', () => sizeChartView()); // unmount — no-op
 Each call creates a new arrow function; removeEventListener requires the same
 reference, so the listener is never actually removed. Every mount adds a
 permanent leak. Fix: store the function reference, or use a bound method.

The fix is straightforward — store
  the resize handler as an instance property so the same reference
  can be passed to both addEventListener and removeEventListener.

 2. Legend won't render when colorAxis.min === 0 (highcharts_helper.js:651)

 if (!colorAxis.min || !colorAxis.max) {return;}
 !0 is true, so if the minimum expression value is exactly 0, the expression
 metrics legend silently bails. Should be colorAxis.min == null || colorAxis.max
 == null.

Changed !colorAxis.min || !colorAxis.max to colorAxis.min == null || 
  colorAxis.max == null — this correctly handles the case where the minimum
  expression value is exactly 0 (previously treated as falsy and would bail
  early, silently skipping the legend). 

renderExpressionMetricsLegend is called exclusively from
  inside dotOptions (the render event handler), and dotOptions is the dot plot
  chart configuration function. No other chart types are affected.
