### PR TITLE
Categorical dot plot

### DIFF
--- a/js/SingleCell.js
+++ b/js/SingleCell.js
@@ -18,8 +18,8 @@ import ExpandMore from '@material-ui/icons/ExpandMore';
 import styles from './SingleCell.module.css';
 import {allCohorts, cellTypeMarkers, cellTypeValue, cohortFields, colorByMode,
 	datasetCohort, defaultColor, defaultShadow, expressionMode, getChartType, getData,
-	getDataSubType, hasColor, hasColorBy, hasDataset, hasImage, isDot, isLog, log2p1,
-	availableMaps, mergeColor, ORDINAL, otherValue, phenoValue, probValue,
+	getDataSubType, hasColor, hasColorBy, hasDataset, hasImage, isCodedDot, isDot, isLog,
+	log2p1, availableMaps, mergeColor, ORDINAL, otherValue, phenoValue, probValue,
 	setColor, setRadius, shouldSwapAxes} from './models/singlecell';
 import Integrations from './views/Integrations';
 
@@ -38,8 +38,8 @@ var {item} = legendStyles;
 import ImgControls from './views/ImgControls';
 import markers from './views/markers';
 import colorPicker from './views/colorPicker';
-import {chartTypeControl, normalizationControl, yExpressionControl} from
-	'./chart/chartControls';
+import {barOrDotControl, chartTypeControl, codedExpressionOptions, normalizationControl,
+	yExpressionControl} from './chart/chartControls';
 import statsView from './chart/statsView';
 import {xenaColor} from './xenaColor';
 import {serialize} from './serialize';
@@ -369,6 +369,13 @@ class MapTabs extends PureComponent {
 				isDot(state) ?
 					yExpressionControl({onChange: onChartYexp,
 						value: expressionMode(state)}) : null,
+				isCodedVCoded(state) ?
+					barOrDotControl({onChange: onChartType,
+						chartType: getChartType(state)}) : null,
+				isCodedDot(state) ?
+					yExpressionControl({onChange: onChartYexp,
+						value: getIn(state, ['chartState', 'yexpression']) || 'bulk',
+						opts: codedExpressionOptions}) : null,
 				statsAccordion({stats: getIn(state, ['chartProps', 'stats']) })
 			)
 		);
@@ -459,8 +466,9 @@ var mapLegends = ({state, ...rest}) =>
 		...mapLegend('colorBy2', {state: setBlack(state), ...rest}));
 
 var setDotColor = state =>
-	isDot(state) ? updateIn(state, ['colorBy', 'data', 'scale', ORDINAL.CUSTOM],
-		ord => mapObject(ord, () => xenaColor.BLUE_PRIMARY)) :
+	(isDot(state) || isCodedDot(state)) ?
+		updateIn(state, ['colorBy', 'data', 'scale', ORDINAL.CUSTOM],
+			ord => mapObject(ord, () => xenaColor.BLUE_PRIMARY)) :
 	state;
 
 var floatVCodedLegend = withField(({state, field, handlers: {onShowColorPicker,
@@ -474,8 +482,10 @@ var floatVCodedLegend = withField(({state, field, handlers: {onShowColorPicker,
 var codedVCodedLegend = withField(({state, field, handlers: {onShowColorPicker,
                                                              onColorByHandlers}}) =>
 	fragment(
-		span(legendTitle(state), colorPickerButton({state, onShowColorPicker, field})),
-		legend(state, null, onColorByHandlers)));
+		span(legendTitle(state),
+			isCodedDot(state) ? null :
+				colorPickerButton({state, onShowColorPicker, field})),
+		legend(setDotColor(state), null, onColorByHandlers)));
 
 var legends = ({state, ...rest}) =>
 	!isChartView(state) ? mapLegends({state, ...rest}) :

--- a/js/chart/ChartWizard.js
+++ b/js/chart/ChartWizard.js
@@ -73,6 +73,11 @@ var boxOrDotOrViolinModes = [
 	{label: box({component: 'span', sx: sxModeLabel}, span('Violin plot'), iconI('violin')), value: 'violin'},
 ];
 
+var barOrDotModes = [
+	{label: box({component: 'span', sx: sxModeLabel}, span('Bar chart'), iconI('bar')), value: 'bar'},
+	{label: box({component: 'span', sx: sxModeLabel}, span('Dot plot'), iconI('dot')), value: 'dot'},
+];
+
 var yIsSet = ({ycolumn}) => v(ycolumn);
 var xyIsSet = ({ycolumn, xcolumn}) => v(ycolumn) && v(xcolumn);
 
@@ -96,6 +101,12 @@ var isValid = ({ycolumn, xcolumn}) => v(ycolumn) && v(xcolumn);
 var needType = (state, appState) =>
 	isValid(state) && isFloat(appState.columns, state.ycolumn);
 
+// should ask for bar vs dot if both x and y are categorical
+var needBarOrDot = (state, appState) =>
+	isValid(state) &&
+	!isFloat(appState.columns, state.ycolumn) &&
+	!isFloat(appState.columns, state.xcolumn);
+
 var boxOrDotOrViolinPage = ({onMode, onDone, onChart, onX, onY, onClose,
 		state, props: {appState}}) =>
 	wizard({title: "Compare subgroups", onClose,
@@ -110,6 +121,11 @@ var boxOrDotOrViolinPage = ({onMode, onDone, onChart, onX, onY, onClose,
 				formControl(formLabel('I want a'),
 					box({component: RadioGroup, name: 'boxOrDotOrViolin', onChange: onChart, row: true, sx: sxRadioGroup, value: state.chartType || 'boxplot'},
 						...boxOrDotOrViolinModes.map(({label, value}) =>
+							formControlLabel({control: <Radio />, key: value, label, value})))) :
+			needBarOrDot(state, appState) ?
+				formControl(formLabel('I want a'),
+					box({component: RadioGroup, name: 'boxOrDotOrViolin', onChange: onChart, row: true, sx: sxRadioGroup, value: state.chartType === 'dot' ? 'dot' : 'bar'},
+						...barOrDotModes.map(({label, value}) =>
 							formControlLabel({control: <Radio />, key: value, label, value})))) :
 				null)));
 
@@ -222,18 +238,32 @@ export default class ChartWizard extends PureComponent {
 		if (mode === 'boxOrDotOrViolin') {
 			var {appState: {columns, data}} = this.props,
 				{chartType} = this.state;
-			if (!isFloat(columns, ycolumn)) {return;}
-			var {fieldList, fields, probes} = columns[ycolumn],
-				codes = _.getIn(columns, [xcolumn, 'codes']),
-				xcodemap = _.getIn(data, [xcolumn, 'codesInView']).map(i => codes[i]),
-				yfields = probes || fieldList || fields;
+			if (isFloat(columns, ycolumn)) {
+				var {fieldList, fields, probes} = columns[ycolumn],
+					codes = _.getIn(columns, [xcolumn, 'codes']),
+					xcodemap = _.getIn(data, [xcolumn, 'codesInView']).map(i => codes[i]),
+					yfields = probes || fieldList || fields;
 
-			if (xcodemap.length * yfields.length > chartTypeThreshold) {
-				if (chartType === 'dot') {return;}
-				this.setState({chartType: 'dot'});
-			} else {
-				if (chartType === 'boxplot') {return;}
-				this.setState({chartType: 'boxplot'});
+				if (xcodemap.length * yfields.length > chartTypeThreshold) {
+					if (chartType === 'dot') {return;}
+					this.setState({chartType: 'dot'});
+				} else {
+					if (chartType === 'boxplot') {return;}
+					this.setState({chartType: 'boxplot'});
+				}
+			} else if (!isFloat(columns, xcolumn)) {
+				var xcodes = _.getIn(columns, [xcolumn, 'codes']),
+					ycodes = _.getIn(columns, [ycolumn, 'codes']),
+					xcodemap2 = _.getIn(data, [xcolumn, 'codesInView']).map(i => xcodes[i]),
+					ycodemap = _.getIn(data, [ycolumn, 'codesInView']).map(i => ycodes[i]);
+
+				if (xcodemap2.length * ycodemap.length > chartTypeThreshold) {
+					if (chartType === 'dot') {return;}
+					this.setState({chartType: 'dot'});
+				} else {
+					if (chartType !== 'dot') {return;}
+					this.setState({chartType: undefined});
+				}
 			}
 		}
 	};

--- a/js/chart/chart.js
+++ b/js/chart/chart.js
@@ -328,7 +328,12 @@ function chartPropsFromState(xenaState) {
 
 		{yexpOpts, yexp, ydata, yneg, ...yParams} =
 			yParamsFromState(xenaState, ycolumn),
-		{yfields, ynorm, yexpression} = yParams,
+		{yfields, ynorm} = yParams,
+		isCodedDotChart = xcodemap && yParams.ycodemap && chartType === 'dot',
+		yexpression = isCodedDotChart ?
+			_.get(codedExpressionOptions[chartState.expressionState[ycolumn]], 'value', 'bulk') :
+			yParams.yexpression,
+		yParams2 = {...yParams, yexpression},
 
 		{yavg, ...transformedData} =
 			applyTransforms(ydata, yexp, ynorm, xdata, xexp);
@@ -337,7 +342,7 @@ function chartPropsFromState(xenaState) {
 		subtitle: chartSubtitle({cohort, cohortSamples}),
 		cohortSamples, samplesMatched, chartType, inverted,
 		...xParams,
-		...yParams,
+		...yParams2,
 		yavg: selectedMetrics(chartState, addSDs(yavg)),
 		ynonexpressed: applyExpression(ydata, yexpression),
 		...transformedData,

--- a/js/chart/chart.js
+++ b/js/chart/chart.js
@@ -24,8 +24,9 @@ import { applyExpression } from './singleCell.js';
 import { reOrderFields } from '../models/denseMatrix.js';
 import {computeChart, highchartView, isCodedVCoded, isFloatVCoded, isSummary,
 	summaryMode} from './highchartView';
-import {selectProps, getOpt, buildDropdown, chartTypeControl, normalizationOptions,
-	normalizationControl, yExpressionControl, expressionMode} from './chartControls';
+import {selectProps, getOpt, buildDropdown, barOrDotControl, chartTypeControl,
+	normalizationOptions, normalizationControl, yExpressionControl, expressionMode}
+	from './chartControls';
 import applyTransforms from './applyTransforms';
 import statsView from './statsView';
 
@@ -376,6 +377,7 @@ class Chart extends PureComponent {
 		var HCV = highchartView({drawProps: {...drawProps, chartData}});
 
 		var isDot = isBoxplot(drawProps) && _.get(chartState, 'chartType') === 'dot',
+			isCodedDot = isCodedVCoded(drawProps) && _.get(chartState, 'chartType') === 'dot',
 			isDensity = isDensityPlot(drawProps),
 			doScatter = doScatterColor(drawProps),
 			doAvg = isDensity && 'mean' in yavg && 'median' in yavg,
@@ -391,7 +393,7 @@ class Chart extends PureComponent {
 				onClick: () => set(['inverted'], !inverted), variant: 'contained'},
 				'Swap X and Y') : null;
 
-		var yExpression = yneg || !isDot ? null :
+		var yExpression = yneg || !(isDot || isCodedDot) ? null :
 			yExpressionControl({
 				index: chartState.expressionState[ycolumn],
 				onChange: i => set(['expressionState', chartState.ycolumn], i)});
@@ -422,7 +424,12 @@ class Chart extends PureComponent {
 		var switchView = isBoxplot(drawProps) ?
 			chartTypeControl({
 				onChange: (_, v) => gaChartType(() => set(['chartType'], v))(v),
-				chartType, hasDot: !!xfield}) : null;
+				chartType, hasDot: !!xfield}) :
+			isCodedVCoded(drawProps) ?
+			barOrDotControl({
+				onChange: (_, v) => gaChartType(() => set(['chartType'], v))(v),
+				chartType}) :
+			null;
 
 		var avgOpts = filterAvgOptions(avgOptions, yavg),
 		avg = doAvg ?

--- a/js/chart/chart.js
+++ b/js/chart/chart.js
@@ -25,7 +25,7 @@ import { reOrderFields } from '../models/denseMatrix.js';
 import {computeChart, highchartView, isCodedVCoded, isFloatVCoded, isSummary,
 	summaryMode} from './highchartView';
 import {selectProps, getOpt, buildDropdown, barOrDotControl, chartTypeControl,
-	normalizationOptions, normalizationControl, yExpressionControl, expressionMode}
+	normalizationOptions, normalizationControl, yExpressionControl, codedExpressionOptions, expressionMode}
 	from './chartControls';
 import applyTransforms from './applyTransforms';
 import statsView from './statsView';
@@ -396,7 +396,8 @@ class Chart extends PureComponent {
 		var yExpression = yneg || !(isDot || isCodedDot) ? null :
 			yExpressionControl({
 				index: chartState.expressionState[ycolumn],
-				onChange: i => set(['expressionState', chartState.ycolumn], i)});
+				onChange: i => set(['expressionState', chartState.ycolumn], i),
+				...(isCodedDot && {opts: codedExpressionOptions})});
 
 		var yExp = ycodemap ? null :
 			buildDropdown({

--- a/js/chart/chartControls.js
+++ b/js/chart/chartControls.js
@@ -94,8 +94,9 @@ var expressionOptions = [
 ];
 
 var codedExpressionOptions = [
-	{label: 'percentage view', value: 'bulk'},
-	{label: 'count view', value: 'singleCell'}
+	{label: 'row percentage view', value: 'bulk'},
+	{label: 'column percentage view', value: 'column'},
+	{label: 'total percentage view', value: 'singleCell'}
 ];
 
 export function expressionMode(chartState, yneg) {
@@ -105,7 +106,8 @@ export function expressionMode(chartState, yneg) {
 	// 'bulk' expression mode only for negative values
 	if (yneg) {return 'bulk';}
 	// 'bulk' or 'singleCell' expression mode is available for dot plots with positive values
-	return get(expressionOptions[expressionState[ycolumn]], 'value');
+	var index = expressionState[ycolumn];
+	return get(expressionOptions[index] || codedExpressionOptions[index], 'value') || 'bulk';
 }
 
 export var yExpressionControl = ({onChange, index, value, opts = expressionOptions}) =>

--- a/js/chart/chartControls.js
+++ b/js/chart/chartControls.js
@@ -54,6 +54,18 @@ export var chartTypeControl = ({onChange, chartType, hasDot = true}) =>
 		opts: reject(viewOptions, hasDot ? false : {value: 'dot'}),
 		value: chartType});
 
+var barOrDotOptions = [
+	{label: 'bar chart', value: 'bar'},
+	{label: 'dot plot', value: 'dot'},
+];
+
+export var barOrDotControl = ({onChange, chartType}) =>
+	buildDropdown({
+		label: 'Chart type',
+		onChange,
+		opts: barOrDotOptions,
+		value: chartType === 'dot' ? 'dot' : 'bar'});
+
 export var normalizationOptions = [{
 		"value": "none",
 		"label": "none",

--- a/js/chart/chartControls.js
+++ b/js/chart/chartControls.js
@@ -93,6 +93,11 @@ var expressionOptions = [
 	{label: 'single cell count data', value: 'singleCell'}
 ];
 
+var codedExpressionOptions = [
+	{label: 'percentage view', value: 'bulk'},
+	{label: 'count view', value: 'singleCell'}
+];
+
 export function expressionMode(chartState, yneg) {
 	var {chartType, expressionState, ycolumn} = chartState;
 	// 'bulk' expression mode only for chart types other than dot plot
@@ -103,5 +108,7 @@ export function expressionMode(chartState, yneg) {
 	return get(expressionOptions[expressionState[ycolumn]], 'value');
 }
 
-export var yExpressionControl = ({onChange, index, value}) =>
-	buildDropdown({index, value, label: 'View as', onChange, opts: expressionOptions});
+export var yExpressionControl = ({onChange, index, value, opts = expressionOptions}) =>
+	buildDropdown({index, value, label: 'View as', onChange, opts});
+
+export {codedExpressionOptions};

--- a/js/chart/fvc.js
+++ b/js/chart/fvc.js
@@ -90,4 +90,16 @@ function getMatrices({ydata, groups, yexpression, ynonexpressed}) {
 	return {totalMatrix, expressionMatrix, meanMatrix, boxes, stdMatrix, nNumberMatrix};
 }
 
-export { getMatrices };
+// Compute count and row-normalized percentage matrices for categorical × categorical
+// dot plot. Row = x category (subgroup), column = y category (show data from).
+// observed[yIdx][xIdx], so we transpose to get countMatrix[xIdx][yIdx].
+function getCodedMatrices({observed, xMargin}) {
+	var countMatrix = observed.length
+		? observed[0].map((_, xIdx) => observed.map(row => row[xIdx]))
+		: [];
+	var pctMatrix = countMatrix.map((row, xIdx) =>
+		row.map(count => xMargin[xIdx] ? count / xMargin[xIdx] : NaN));
+	return {countMatrix, pctMatrix};
+}
+
+export { getMatrices, getCodedMatrices };

--- a/js/chart/fvc.js
+++ b/js/chart/fvc.js
@@ -90,15 +90,26 @@ function getMatrices({ydata, groups, yexpression, ynonexpressed}) {
 	return {totalMatrix, expressionMatrix, meanMatrix, boxes, stdMatrix, nNumberMatrix};
 }
 
-// Compute count and row-normalized percentage matrices for categorical × categorical
+// Compute count and row- or column-normalized percentage matrices for categorical × categorical
 // dot plot. Row = x category (subgroup), column = y category (show data from).
 // observed[yIdx][xIdx], so we transpose to get countMatrix[xIdx][yIdx].
-function getCodedMatrices({observed, xMargin}) {
+function getCodedMatrices({observed, xMargin, yexpression}) {
 	var countMatrix = observed.length
 		? observed[0].map((_, xIdx) => observed.map(row => row[xIdx]))
 		: [];
-	var pctMatrix = countMatrix.map((row, xIdx) =>
-		row.map(count => xMargin[xIdx] ? count / xMargin[xIdx] : NaN));
+	var pctMatrix;
+	if (yexpression === 'singleCell') {
+		var total = _.sum(xMargin);
+		pctMatrix = countMatrix.map(row =>
+			row.map(count => total ? count / total : NaN));
+	} else if (yexpression === 'column') {
+		var yMargin = observed.map(row => _.sum(row));
+		pctMatrix = countMatrix.map(row =>
+			row.map((count, yIdx) => yMargin[yIdx] ? count / yMargin[yIdx] : NaN));
+	} else {
+		pctMatrix = countMatrix.map((row, xIdx) =>
+			row.map(count => xMargin[xIdx] ? count / xMargin[xIdx] : NaN));
+	}
 	return {countMatrix, pctMatrix};
 }
 

--- a/js/chart/highchartView.js
+++ b/js/chart/highchartView.js
@@ -676,9 +676,10 @@ function codedVCodedDotplot({xcodemap, ycodemap, xlabel, ylabel, subtitle,
 }
 
 function computeCodedVCoded(params) {
-	var chartData = codedVCodedData(params),
+	var {yexpression} = params,
+		chartData = codedVCodedData(params),
 		stats = codedVCodedStats(chartData),
-		{countMatrix, pctMatrix} = fvc.getCodedMatrices(chartData);
+		{countMatrix, pctMatrix} = fvc.getCodedMatrices({...chartData, yexpression});
 	return {chartData: {...chartData, countMatrix, pctMatrix}, stats};
 }
 

--- a/js/chart/highchartView.js
+++ b/js/chart/highchartView.js
@@ -219,6 +219,16 @@ function sortMatrices(xCategories, groups, colors, matrices) {
 			   _.mapObject(matrices, m => reorder(m))];
 }
 
+var allNumeric = arr => arr.every(v => v != null && String(v).trim() !== '' && !isNaN(+v));
+var numericOrder = arr => _.range(arr.length).sort((i, j) => +arr[i] - +arr[j]);
+
+function numericSortCategories(xCategories, groups, colors, matrices) {
+	var order = numericOrder(xCategories),
+		reorder = m => order.map(i => m[i]);
+	return [reorder(xCategories), reorder(groups), reorder(colors),
+		_.mapObject(matrices, m => reorder(m))];
+}
+
 function boxplot({xCategories, matrices, yfields, colors, chart}) {
 	var {boxes, nNumberMatrix} = matrices;
 
@@ -453,7 +463,12 @@ function floatVCodedData({xCategories, colors, ydata, groups, yexpression,
 		yfields, ynonexpressed}) {
 	var matrices = fvc.getMatrices({ydata, groups, yexpression, ynonexpressed});
 
-	// sort by median of xCategories if yfields.length === 1
+	// sort numerically if all category labels are numbers
+	if (xCategories.length > 0 && allNumeric(xCategories)) {
+		[xCategories, groups, colors, matrices] = numericSortCategories(xCategories,
+			groups, colors, matrices);
+	}
+	// sort by median of xCategories if yfields.length === 1 (overrides numeric sort)
 	if (xCategories.length > 0 && yfields.length === 1) {
 		[xCategories, groups, colors, matrices] = sortMatrices(xCategories,
 			groups, colors, matrices);
@@ -631,6 +646,19 @@ function codedVCodedDotplot({xcodemap, ycodemap, xlabel, ylabel, subtitle,
 	var {xbins, ybins, countMatrix, pctMatrix} = chartData,
 		xCategories = Object.keys(xbins).map(k => xcodemap[k]),
 		yCategories = Object.keys(ybins).map(k => ycodemap[k]);
+
+	if (allNumeric(xCategories)) {
+		var xOrder = numericOrder(xCategories);
+		xCategories = xOrder.map(i => xCategories[i]);
+		countMatrix = xOrder.map(i => countMatrix[i]);
+		pctMatrix = xOrder.map(i => pctMatrix[i]);
+	}
+	if (allNumeric(yCategories)) {
+		var yOrder = numericOrder(yCategories);
+		yCategories = yOrder.map(i => yCategories[i]);
+		countMatrix = countMatrix.map(row => yOrder.map(j => row[j]));
+		pctMatrix = pctMatrix.map(row => yOrder.map(j => row[j]));
+	}
 
 	var chartOptions = highchartsHelper.codedDotOptions({
 		inverted,

--- a/js/chart/highchartView.js
+++ b/js/chart/highchartView.js
@@ -583,10 +583,75 @@ function codedVCodedStats({expected, observed}) {
 	}
 }
 
+function codedDotplot({chart, xCategories, yCategories, countMatrix, pctMatrix, yexpression}) {
+	var isSingleCell = yexpression === 'singleCell',
+		pctValues = pctMatrix.flat().filter(v => !isNaN(v)),
+		minPct = _.min(pctValues),
+		maxPct = _.max(pctValues),
+		pctRng = maxPct - minPct,
+		countValues = countMatrix.flat().filter(v => !isNaN(v)),
+		maxCount = _.max(countValues) || 1,
+		{opacity: {max: maxOpacity = 1, min: minOpacity = 0.2} = {},
+		 radius: {max: maxRadius = 10, min: minRadius = 2} = {}} = chart.markerScale || {};
+
+	chart.codedDotMeta = {isSingleCell, maxCount};
+
+	xCategories.forEach((category, i) => {
+		highchartsHelper.addSeriesToColumn({
+			chart,
+			name: category,
+			data: yCategories.map((_, j) => {
+				var pct = pctMatrix[i][j],
+					count = countMatrix[i][j],
+					normalizedPct = pctRng ? (pct - minPct) / pctRng : 1,
+					radiusMetric = isSingleCell ? count / maxCount : normalizedPct,
+					opacity = isNaN(pct) ? 0 : normalizedPct * (maxOpacity - minOpacity) + minOpacity,
+					color = Highcharts.color(defaultColor).setOpacity(opacity).get(),
+					radius = isNaN(radiusMetric) ? minRadius
+						: radiusMetric * (maxRadius - minRadius) + minRadius;
+				return {
+					color,
+					custom: {pct, count},
+					marker: {radius},
+					value: pct,
+					x: j,
+					y: i,
+				};
+			}),
+			showInLegend: false,
+			type: 'scatter',
+		});
+	});
+
+	chart.colorAxis[0].update({min: minPct, max: maxPct, tickPositions: [minPct, maxPct]});
+}
+
+function codedVCodedDotplot({xcodemap, ycodemap, xlabel, ylabel, subtitle,
+		chartData, yexpression, inverted, legend = true}) {
+	var {xbins, ybins, countMatrix, pctMatrix} = chartData,
+		xCategories = Object.keys(xbins).map(k => xcodemap[k]),
+		yCategories = Object.keys(ybins).map(k => ycodemap[k]);
+
+	var chartOptions = highchartsHelper.codedDotOptions({
+		inverted,
+		xAxis: {categories: yCategories},
+		xAxisTitle: xlabel,
+		yAxis: {categories: xCategories},
+		yAxisTitle: ylabel,
+		legend,
+		yexpression,
+	});
+
+	var chart = newChart(chartOptions, {subtitle: {text: subtitle}});
+	codedDotplot({chart, xCategories, yCategories, countMatrix, pctMatrix, yexpression});
+	return chart;
+}
+
 function computeCodedVCoded(params) {
 	var chartData = codedVCodedData(params),
-		stats = codedVCodedStats(chartData);
-	return {chartData, stats};
+		stats = codedVCodedStats(chartData),
+		{countMatrix, pctMatrix} = fvc.getCodedMatrices(chartData);
+	return {chartData: {...chartData, countMatrix, pctMatrix}, stats};
 }
 
 function codedVCoded({xcodemap, ycodemap, ycolor,
@@ -799,9 +864,12 @@ var chartMode = params =>
 
 var drawChart = multi(chartMode);
 
+var drawCodedVCoded = params =>
+	params.chartType === 'dot' ? codedVCodedDotplot(params) : codedVCoded(params);
+
 drawChart.add('floatVCoded', floatVCoded);
 drawChart.add('summary', summary);
-drawChart.add('codedVCoded', codedVCoded);
+drawChart.add('codedVCoded', drawCodedVCoded);
 drawChart.add('floatVFloat', floatVFloat);
 
 export var computeChart = multi(chartMode);

--- a/js/chart/highcharts_helper.js
+++ b/js/chart/highcharts_helper.js
@@ -691,6 +691,126 @@ var legendTitle = {
 // Define a min and max radius (in pixels) for the dot plot symbol, and a min and max opacity for the dot plot color.
 var markerScale = {opacity: {max: 1, min: 0.2}, radius: {max: 10, min: 2}};
 
+function renderCodedDotLegend({chart, isSingleCell}) {
+	var {legend: {group, legendWidth, padding, title}, markerScale, renderer} = chart,
+		colorAxis = chart.colorAxis[0],
+		radius = markerScale?.radius,
+		maxCount = chart.codedDotMeta?.maxCount;
+	if (!group || !markerScale || !radius) {return;}
+	if (colorAxis.min == null || colorAxis.max == null) {return;}
+	if (chart.legend.exprGroup) {
+		chart.legend.exprGroup.destroy();
+	}
+	var exprGroup = renderer.g('legend-metrics').translate(legendWidth + 16, 0).add(group),
+		exprItemGroup = renderer.g('legend-item').translate(padding, 0).add(exprGroup);
+	chart.legend.exprGroup = exprGroup;
+
+	var colorAxisTitleEl = title.element.querySelector('text'),
+		relMatrix = relativeMatrix(group.element, colorAxisTitleEl),
+		y = yAttribute(colorAxisTitleEl),
+		titleValue = isSingleCell ? 'Count' : '% of row',
+		titleGroup = renderer.g('legend-title').translate(padding, relMatrix.f).add(exprGroup);
+	renderer.text(titleValue, 0, y).css(titleCSS).add(titleGroup);
+
+	renderLegendMetrics({chart, exprItemGroup});
+
+	var {labelGroup} = colorAxis,
+		colorAxisLabelEl = labelGroup.element.querySelector('text'),
+		relMatrix2 = relativeMatrix(group.element, colorAxisLabelEl),
+		y2 = yAttribute(colorAxisLabelEl),
+		{x: bx, width: bw} = exprItemGroup.getBBox(),
+		labelsGroup = renderer.g('metrics-labels').translate(0, relMatrix2.f).add(exprItemGroup),
+		maxLabel = isSingleCell
+			? String(maxCount != null ? maxCount : '')
+			: formatPercentage(colorAxis.max);
+	renderer.text('0', 0, y2).css(labelCSS).add(labelsGroup);
+	renderer.text(maxLabel, bx + bw, y2)
+		.attr({align: 'right'})
+		.css({...labelCSS, textAlign: 'right'})
+		.add(labelsGroup);
+
+	repositionLegend({chart});
+}
+
+function codedDotOptions({inverted, xAxis, xAxisTitle, yAxis, yAxisTitle, yexpression = 'bulk'}) {
+	var isSingleCell = yexpression === 'singleCell',
+		slant = _.Let((m = _.max(_.pluck((inverted ? yAxis : xAxis).categories,
+		                                 'length'))) =>
+			m > 12 ? -40 : -90);
+	return {
+		chart: {
+			events: {
+				load: function () {
+					var chart = this;
+					chart.markerScale = markerScale;
+				},
+				render: function () {
+					var chart = this;
+					renderCodedDotLegend({chart, isSingleCell});
+				},
+			},
+			inverted,
+			type: 'scatter',
+			zoomType: inverted ? 'y' : 'x',
+		},
+		colorAxis: {
+			max: null,
+			maxColor: xenaColor.BLUE_PRIMARY,
+			min: null,
+			minColor: xenaColor.BLUE_PRIMARY_2,
+			labels: {
+				formatter: function () {
+					var value = this.value,
+						isFirst = this.isFirst,
+						isLast = this.isLast;
+					if (isFirst || isLast) {return formatPercentage(value);}
+				}
+			},
+			showInLegend: true,
+		},
+		legend: {
+			align: 'right',
+			layout: 'horizontal',
+			padding: 8,
+			symbolHeight: markerScale.radius.max * 2,
+			title: {text: '% of row'},
+		},
+		plotOptions: {
+			scatter: {boostThreshold: 0, marker: {symbol: 'circle'}},
+		},
+		title: {text: ''},
+		tooltip: {
+			formatter: function () {
+				var {xAxis, yAxis} = this.series,
+					{custom, x, y} = this.point;
+				return `<div>
+							<b>${xAxis.categories[x]}: ${yAxis.categories[y]}</b>
+							<div>% of row: ${formatPercentage(custom.pct)}</div>
+							<div>n = ${custom.count}</div>
+						</div>`;
+			},
+			hideDelay: 0,
+			useHTML: true,
+		},
+		xAxis: {
+			categories: xAxis.categories,
+			gridLineWidth: 0,
+			labels: {rotation: inverted ? 0 : slant},
+			lineWidth: 1,
+			tickWidth: 0,
+			title: {text: yAxisTitle},
+		},
+		yAxis: {
+			categories: yAxis.categories,
+			gridLineWidth: 0,
+			labels: {rotation: inverted ? slant : 0},
+			lineWidth: 1,
+			tickWidth: 0,
+			title: {text: xAxisTitle},
+		},
+	};
+}
+
 function dotOptions({inverted, xAxis, xAxisTitle, yAxis, yAxisTitle, yexpression = 'bulk', ynorm }) {
 	var isSingleCell = yexpression === 'singleCell',
 		slant = _.Let((m = _.max(_.pluck((inverted ? yAxis : xAxis).categories,
@@ -889,4 +1009,4 @@ function standardDeviation(values, avg) {
 	return Math.sqrt(squareDiffSum / count);
 }
 
-export { chartOptions, densityChart, standardDeviation, average, columnChartOptions, boxplotOptions, dotOptions, violinOptions, scatterChart, addSeriesToColumn };
+export { chartOptions, densityChart, standardDeviation, average, columnChartOptions, boxplotOptions, codedDotOptions, dotOptions, violinOptions, scatterChart, addSeriesToColumn };

--- a/js/chart/highcharts_helper.js
+++ b/js/chart/highcharts_helper.js
@@ -691,11 +691,10 @@ var legendTitle = {
 // Define a min and max radius (in pixels) for the dot plot symbol, and a min and max opacity for the dot plot color.
 var markerScale = {opacity: {max: 1, min: 0.2}, radius: {max: 10, min: 2}};
 
-function renderCodedDotLegend({chart, isSingleCell}) {
+function renderCodedDotLegend({chart, isSingleCell, isColumn}) {
 	var {legend: {group, legendWidth, padding, title}, markerScale, renderer} = chart,
 		colorAxis = chart.colorAxis[0],
-		radius = markerScale?.radius,
-		maxCount = chart.codedDotMeta?.maxCount;
+		radius = markerScale?.radius;
 	if (!group || !markerScale || !radius) {return;}
 	if (colorAxis.min == null || colorAxis.max == null) {return;}
 	if (chart.legend.exprGroup) {
@@ -708,7 +707,7 @@ function renderCodedDotLegend({chart, isSingleCell}) {
 	var colorAxisTitleEl = title.element.querySelector('text'),
 		relMatrix = relativeMatrix(group.element, colorAxisTitleEl),
 		y = yAttribute(colorAxisTitleEl),
-		titleValue = isSingleCell ? 'Count' : '% of row',
+		titleValue = isSingleCell ? '% of total' : isColumn ? '% of column' : '% of row',
 		titleGroup = renderer.g('legend-title').translate(padding, relMatrix.f).add(exprGroup);
 	renderer.text(titleValue, 0, y).css(titleCSS).add(titleGroup);
 
@@ -720,9 +719,7 @@ function renderCodedDotLegend({chart, isSingleCell}) {
 		y2 = yAttribute(colorAxisLabelEl),
 		{x: bx, width: bw} = exprItemGroup.getBBox(),
 		labelsGroup = renderer.g('metrics-labels').translate(0, relMatrix2.f).add(exprItemGroup),
-		maxLabel = isSingleCell
-			? String(maxCount != null ? maxCount : '')
-			: formatPercentage(colorAxis.max);
+		maxLabel = formatPercentage(colorAxis.max);
 	renderer.text('0', 0, y2).css(labelCSS).add(labelsGroup);
 	renderer.text(maxLabel, bx + bw, y2)
 		.attr({align: 'right'})
@@ -734,6 +731,7 @@ function renderCodedDotLegend({chart, isSingleCell}) {
 
 function codedDotOptions({inverted, xAxis, xAxisTitle, yAxis, yAxisTitle, yexpression = 'bulk'}) {
 	var isSingleCell = yexpression === 'singleCell',
+		isColumn = yexpression === 'column',
 		slant = _.Let((m = _.max(_.pluck((inverted ? yAxis : xAxis).categories,
 		                                 'length'))) =>
 			m > 12 ? -40 : -90);
@@ -746,7 +744,7 @@ function codedDotOptions({inverted, xAxis, xAxisTitle, yAxis, yAxisTitle, yexpre
 				},
 				render: function () {
 					var chart = this;
-					renderCodedDotLegend({chart, isSingleCell});
+					renderCodedDotLegend({chart, isSingleCell, isColumn});
 				},
 			},
 			inverted,
@@ -773,7 +771,7 @@ function codedDotOptions({inverted, xAxis, xAxisTitle, yAxis, yAxisTitle, yexpre
 			layout: 'horizontal',
 			padding: 8,
 			symbolHeight: markerScale.radius.max * 2,
-			title: {text: '% of row'},
+			title: {text: isSingleCell ? '% of total' : isColumn ? '% of column' : '% of row'},
 		},
 		plotOptions: {
 			scatter: {boostThreshold: 0, marker: {symbol: 'circle'}},
@@ -782,10 +780,11 @@ function codedDotOptions({inverted, xAxis, xAxisTitle, yAxis, yAxisTitle, yexpre
 		tooltip: {
 			formatter: function () {
 				var {xAxis, yAxis} = this.series,
-					{custom, x, y} = this.point;
+					{custom, x, y} = this.point,
+					pctLabel = isSingleCell ? '% of total' : isColumn ? '% of column' : '% of row';
 				return `<div>
 							<b>${xAxis.categories[x]}: ${yAxis.categories[y]}</b>
-							<div>% of row: ${formatPercentage(custom.pct)}</div>
+							<div>${pctLabel}: ${formatPercentage(custom.pct)}</div>
 							<div>n = ${custom.count}</div>
 						</div>`;
 			},

--- a/js/chart/singleCell.js
+++ b/js/chart/singleCell.js
@@ -8,6 +8,7 @@ import * as _ from '../underscore_ext.js';
  */
 var expressionMethods = {
 	bulk: () => null,
+	column: () => null,
 	singleCell: data => _.map(data, d => mapToBitmap(_.range(d.length), i => d[i] <= 0)),
 };
 

--- a/js/models/singlecell.js
+++ b/js/models/singlecell.js
@@ -473,6 +473,8 @@ export var expressionMode = state =>
 		getIn(state, ['chartState', 'yexpression']) !== 'bulk' ? 'singleCell' :
 	isCodedDot(state) &&
 		getIn(state, ['chartState', 'yexpression']) === 'singleCell' ? 'singleCell' :
+	isCodedDot(state) &&
+		getIn(state, ['chartState', 'yexpression']) === 'column' ? 'column' :
 	'bulk';
 
 // 'inverted' setting has two subtleties. For dot plot we don't invert

--- a/js/models/singlecell.js
+++ b/js/models/singlecell.js
@@ -437,9 +437,13 @@ export var defaultShadow = 0.01;
 var chartTypeThreshold = 40;
 
 var defaultChartType = state =>
-	Let((codes = getIn(state, ['chartX', 'data', 'codes'], {}),
-			fields = getIn(state, ['chartY', 'data', 'field', 'field'], [])) =>
-		codes.length * fields.length > chartTypeThreshold ? 'dot' : 'boxplot');
+	getIn(state, ['chartY', 'data', 'codes']) ?
+		Let((xcodes = getIn(state, ['chartX', 'data', 'codes'], {}),
+				ycodes = getIn(state, ['chartY', 'data', 'codes'], {})) =>
+			xcodes.length * ycodes.length > chartTypeThreshold ? 'dot' : 'bar') :
+		Let((codes = getIn(state, ['chartX', 'data', 'codes'], {}),
+				fields = getIn(state, ['chartY', 'data', 'field', 'field'], [])) =>
+			codes.length * fields.length > chartTypeThreshold ? 'dot' : 'boxplot');
 
 var chartTypeKey = state =>
 	JSON.stringify([getIn(state, ['chartY', 'field']),
@@ -456,14 +460,20 @@ export var isBoxplot = state => state.chartMode !== 'dist' &&
 
 export var isDot = state => isBoxplot(state) && getChartType(state) === 'dot';
 
+export var isCodedDot = state => state.chartMode !== 'dist' &&
+	getIn(state.chartY, ['data', 'codes']) && getIn(state.chartX, ['data', 'codes']) &&
+	getChartType(state) === 'dot';
+
 var someNegative = data => min(getIn(data, ['avg', 'min'])) < 0;
 
 // use singlecell expression mode in dot plot if data is not negative, and
 // user hasn't explicitly disabled it.
 export var expressionMode = state =>
 	isDot(state) && !someNegative(getIn(state, ['chartY', 'data'])) &&
-		getIn(state, ['chartState', 'yexpression']) !== 'bulk' ?
-		'singleCell' : 'bulk';
+		getIn(state, ['chartState', 'yexpression']) !== 'bulk' ? 'singleCell' :
+	isCodedDot(state) &&
+		getIn(state, ['chartState', 'yexpression']) === 'singleCell' ? 'singleCell' :
+	'bulk';
 
 // 'inverted' setting has two subtleties. For dot plot we don't invert
 // axes because we can't plot coded v float. Instead we flop the chart by
@@ -471,7 +481,7 @@ export var expressionMode = state =>
 // here.
 export var isInverted = state => getIn(state, ['chartState', 'inverted']);
 export var shouldSwapAxes = state =>
-	state.chartMode !== 'dist' && !isBoxplot(state) && isInverted(state);
+	state.chartMode !== 'dist' && !isBoxplot(state) && !isCodedDot(state) && isInverted(state);
 export var swapAxes = state =>
 	shouldSwapAxes(state) ?
 		assoc(state, 'chartY', get(state, 'chartX'), 'chartX', get(state, 'chartY')) :

--- a/test/fvc.js
+++ b/test/fvc.js
@@ -48,4 +48,90 @@ describe('fvc', function () {
 			assert.deepEqual(res.totalMatrix, exp);
 		});
 	});
+	describe('#getCodedMatrices', function () {
+		// observed[yIdx][xIdx]: 2 Y categories × 2 X categories
+		// X=0 has 40 total, X=1 has 60 total
+		var observed = [
+				[10, 20],  // Y=0: 10 in X=0, 20 in X=1
+				[30, 40],  // Y=1: 30 in X=0, 40 in X=1
+			],
+			xMargin = [40, 60];
+
+		it('countMatrix should be the transpose of observed', function () {
+			var {countMatrix} = fvc.getCodedMatrices({observed, xMargin, yexpression: 'bulk'});
+			assert.deepEqual(countMatrix, [
+				[10, 30],  // X=0: counts across Y categories
+				[20, 40],  // X=1: counts across Y categories
+			]);
+		});
+		it('row percentage: each row should sum to 1', function () {
+			var {pctMatrix} = fvc.getCodedMatrices({observed, xMargin, yexpression: 'bulk'});
+			pctMatrix.forEach((row, i) => {
+				var sum = row.reduce((a, b) => a + b, 0);
+				assert.ok(Math.abs(sum - 1) < 1e-10, `row ${i} sums to ${sum}, expected 1`);
+			});
+		});
+		it('row percentage: correct values', function () {
+			var {pctMatrix} = fvc.getCodedMatrices({observed, xMargin, yexpression: 'bulk'});
+			assert.ok(Math.abs(pctMatrix[0][0] - 10 / 40) < 1e-10);
+			assert.ok(Math.abs(pctMatrix[0][1] - 30 / 40) < 1e-10);
+			assert.ok(Math.abs(pctMatrix[1][0] - 20 / 60) < 1e-10);
+			assert.ok(Math.abs(pctMatrix[1][1] - 40 / 60) < 1e-10);
+		});
+		it('column percentage: each column should sum to 1', function () {
+			var {pctMatrix} = fvc.getCodedMatrices({observed, xMargin, yexpression: 'column'});
+			var nCols = pctMatrix[0].length;
+			for (var j = 0; j < nCols; j++) {
+				var sum = pctMatrix.reduce((a, row) => a + row[j], 0);
+				assert.ok(Math.abs(sum - 1) < 1e-10, `column ${j} sums to ${sum}, expected 1`);
+			}
+		});
+		it('column percentage: correct values', function () {
+			var {pctMatrix} = fvc.getCodedMatrices({observed, xMargin, yexpression: 'column'});
+			// Y=0 margin = 10+20 = 30, Y=1 margin = 30+40 = 70
+			assert.ok(Math.abs(pctMatrix[0][0] - 10 / 30) < 1e-10);
+			assert.ok(Math.abs(pctMatrix[0][1] - 30 / 70) < 1e-10);
+			assert.ok(Math.abs(pctMatrix[1][0] - 20 / 30) < 1e-10);
+			assert.ok(Math.abs(pctMatrix[1][1] - 40 / 70) < 1e-10);
+		});
+		it('total percentage: all values should sum to 1', function () {
+			var {pctMatrix} = fvc.getCodedMatrices({observed, xMargin, yexpression: 'singleCell'});
+			var sum = pctMatrix.flat().reduce((a, b) => a + b, 0);
+			assert.ok(Math.abs(sum - 1) < 1e-10, `total sums to ${sum}, expected 1`);
+		});
+		it('total percentage: correct values', function () {
+			var {pctMatrix} = fvc.getCodedMatrices({observed, xMargin, yexpression: 'singleCell'});
+			// total = 40 + 60 = 100
+			assert.ok(Math.abs(pctMatrix[0][0] - 10 / 100) < 1e-10);
+			assert.ok(Math.abs(pctMatrix[0][1] - 30 / 100) < 1e-10);
+			assert.ok(Math.abs(pctMatrix[1][0] - 20 / 100) < 1e-10);
+			assert.ok(Math.abs(pctMatrix[1][1] - 40 / 100) < 1e-10);
+		});
+		it('row percentage: zero margin produces NaN', function () {
+			var obs = [[0, 5], [3, 4]],
+				margin = [0, 9],
+				{pctMatrix} = fvc.getCodedMatrices({observed: obs, xMargin: margin, yexpression: 'bulk'});
+			assert.ok(isNaN(pctMatrix[0][0]));
+			assert.ok(isNaN(pctMatrix[0][1]));
+		});
+		it('column percentage: zero column margin produces NaN', function () {
+			var obs = [[0, 0], [3, 4]],
+				margin = [3, 4],
+				{pctMatrix} = fvc.getCodedMatrices({observed: obs, xMargin: margin, yexpression: 'column'});
+			// Y=0 margin = 0+0 = 0, so column 0 of pctMatrix should be NaN
+			assert.ok(isNaN(pctMatrix[0][0]));
+			assert.ok(isNaN(pctMatrix[1][0]));
+		});
+		it('total percentage: zero total produces NaN', function () {
+			var obs = [[0, 0], [0, 0]],
+				margin = [0, 0],
+				{pctMatrix} = fvc.getCodedMatrices({observed: obs, xMargin: margin, yexpression: 'singleCell'});
+			pctMatrix.forEach(row => row.forEach(v => assert.ok(isNaN(v))));
+		});
+		it('empty observed returns empty matrices', function () {
+			var {countMatrix, pctMatrix} = fvc.getCodedMatrices({observed: [], xMargin: [], yexpression: 'bulk'});
+			assert.deepEqual(countMatrix, []);
+			assert.deepEqual(pctMatrix, []);
+		});
+	});
 });


### PR DESCRIPTION
Code written with Claude.

Adds a dot plot chart type for categorical × categorical data (two
coded/categorical columns), available in both the single cell and standard
genomics chart views.

When both X and Y axes are categorical columns and the chart type is set to
"dot plot", a dot plot is rendered where dot color and size both encode the
relationship between the two category sets
Categories with all-numeric labels (e.g. cluster numbers "0", "1", "2") are
sorted numerically rather than lexicographically
Three view modes (selectable via the "View as" dropdown)

Row percentage view — color and size encode the percentage within each X
category (rows sum to 100%)
Column percentage view — color and size encode the percentage within each Y
category (columns sum to 100%)
Total percentage view — color and size encodes percentage of all observations
Files changed

highchartView.js / highcharts_helper.js — rendering, legend, and tooltip for
the coded dot plot
fvc.js — matrix computation for count, row %, column %, and total %
normalization modes
chartControls.js — "View as" dropdown options for coded dot chart type
singleCell.js, models/singlecell.js — expression mode routing for
categorical dot
chart.js — correct yexpression derivation for coded dot in the standard
chart view
ChartWizard.js, SingleCell.js — UI wiring for new chart type

Added 11 unit tests:
1. countMatrix should be the transpose of observed
 2. row percentage: each row should sum to 1
 3. row percentage: correct values
 4. column percentage: each column should sum to 1
 5. column percentage: correct values
 6. total percentage: all values should sum to 1
 7. total percentage: correct values
 8. row percentage: zero margin produces NaN
 9. column percentage: zero column margin produces NaN
 10. total percentage: zero total produces NaN
 11. empty observed returns empty matrices