### PR TITLE
fixing highcharts axis formatting error for dot plots

### DIFF
--- a/js/chart/highcharts_helper.js
+++ b/js/chart/highcharts_helper.js
@@ -793,16 +793,24 @@ function codedDotOptions({inverted, xAxis, xAxisTitle, yAxis, yAxisTitle, yexpre
 		},
 		xAxis: {
 			categories: xAxis.categories,
+			type: 'category',
 			gridLineWidth: 0,
-			labels: {rotation: inverted ? 0 : slant},
+			labels: {rotation: inverted ? 0 : slant, formatter: function() {
+				var cat = this.axis.categories[this.pos];
+				return cat != null ? cat : '';
+			}},
 			lineWidth: 1,
 			tickWidth: 0,
 			title: {text: yAxisTitle},
 		},
 		yAxis: {
 			categories: yAxis.categories,
+			type: 'category',
 			gridLineWidth: 0,
-			labels: {rotation: inverted ? slant : 0},
+			labels: {rotation: inverted ? slant : 0, formatter: function() {
+				var cat = this.axis.categories[this.pos];
+				return cat != null ? cat : '';
+			}},
 			lineWidth: 1,
 			tickWidth: 0,
 			title: {text: xAxisTitle},
@@ -873,16 +881,24 @@ function dotOptions({inverted, xAxis, xAxisTitle, yAxis, yAxisTitle, yexpression
 		},
 		xAxis: {
 			categories: xAxis.categories,
+			type: 'category',
 			gridLineWidth: 0,
-			labels: {rotation: inverted ? 0 : slant},
+			labels: {rotation: inverted ? 0 : slant, formatter: function() {
+				var cat = this.axis.categories[this.pos];
+				return cat != null ? cat : '';
+			}},
 			lineWidth: 1,
 			tickWidth: 0,
 			title: {text: yAxisTitle},
 		},
 		yAxis: {
 			categories: yAxis.categories,
+			type: 'category',
 			gridLineWidth: 0,
-			labels: {rotation: inverted ? slant : 0},
+			labels: {rotation: inverted ? slant : 0, formatter: function() {
+				var cat = this.axis.categories[this.pos];
+				return cat != null ? cat : '';
+			}},
 			lineWidth: 1,
 			tickWidth: 0,
 			title: {text: xAxisTitle},


### PR DESCRIPTION
Made with Claude

Highcharts was adding an extra tick beyond the last valid category index when
 there were many categories (>10) in both dot plots, because its default endOnTick behavior
 extends the axis to the next "nice" tick at position N. However categories[N]
 is undefined, causing Highcharts to fall back to rendering the raw number. You can see this in the fact that the the number category doesn't actually have a row of dots next to it.

We fixed it by adding a label formatter to both axes in codedDotOptions and
 dotOptions that returns '' (a blank string) for any tick position with no corresponding
 category entry. The key detail was using this.pos (the numeric tick index)
 rather than this.value, which on a type: 'category' axis holds the category
 string and can't be used as an array index, which is what we do for the Violin plot.