### PR TITLE
Small edits in preparation for the next release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ db.sqlite3
 .idea
 .DS_Store
 .directory
+.claude/

--- a/js/chart/chart.module.css
+++ b/js/chart/chart.module.css
@@ -56,7 +56,13 @@
 	box-shadow: none;
 	display: flex;
 	flex-direction: column;
+	margin: 0 !important;
 	min-height: 0;
+}
+
+.chartActionsSecondary::before {
+	display: block !important;
+	opacity: 1 !important;
 }
 
 .chartActionsSecondarySummary {
@@ -65,8 +71,14 @@
 	font-weight: 500;
 	letter-spacing: 0.46px;
 	line-height: 26px;
+	min-height: 0 !important;
 	padding: 16px;
 	text-transform: uppercase;
+}
+
+.chartActionsSecondarySummary :global(.MuiAccordionSummary-content),
+.chartActionsSecondarySummary :global(.MuiAccordionSummary-content.MuiAccordionSummary-expanded) {
+	margin: 0;
 }
 
 .chartActionsSecondaryDetails {

--- a/js/nav.js
+++ b/js/nav.js
@@ -27,7 +27,6 @@ import * as store from './hiddenOpts';
 import Rx from './rx';
 import meta from './meta';
 import BookmarkMenu from './views/BookmarkMenu.js';
-import {GENESETS_VIEWER_URL} from './views/GeneSetViewDialog';
 import {xenaColor} from './xenaColor';
 import {xenaNavTheme} from "./xenaThemeNav";
 
@@ -79,12 +78,6 @@ var helpLink = {
 	target: '_blank'
 };
 
-var geneSetsLink = {
-    href: GENESETS_VIEWER_URL,
-    label: 'Gene Sets',
-    target: '_blank'
-};
-
 var pythonLink = {
     href: helproot + 'overview-of-features/accessing-data-through-python',
     label: 'Python',
@@ -126,9 +119,6 @@ class MoreToolsMenu extends React.Component {
 				>
 					<MenuItem onClick={this.handleSelect.bind(this, pythonLink.href)}>
 						{pythonLink.label}
-					</MenuItem>
-					<MenuItem onClick={this.handleSelect.bind(this, geneSetsLink.href)}>
-						{geneSetsLink.label}
 					</MenuItem>
 				 </Menu>
 			</>
@@ -268,7 +258,7 @@ class XenaNav extends React.Component {
 					<Box component='nav' sx={sxNav}>
 						{routes.map(({label, ...routeProps}) =>
 							<Box component={NavLink} key={label} sx={sxNavLink} {...routeProps}>{label}</Box>)}
-						{getState ? <BookmarkMenu isPublic={isPublic} getState={getState} onImport={onImport}/> : null}
+						{getState && activeLink !== 'singlecell' ? <BookmarkMenu isPublic={isPublic} getState={getState} onImport={onImport}/> : null}
 						<Box component={NavLink} href={helpLink.href} sx={sxNavLink} target={helpLink.target}>Help</Box>
 						<MoreToolsMenu/>
 					</Box>

--- a/js/views/SampleSearch.js
+++ b/js/views/SampleSearch.js
@@ -18,11 +18,6 @@ import HelpBox from '../views/HelpBox';
 import {xenaColor} from '../xenaColor';
 
 // Styles
-var sxHistoryButton = {
-	position: 'absolute',
-	right: 0,
-	top: -12,
-};
 var sxSamplePicker = {
 	marginLeft: 4,
 	'&:hover': {
@@ -163,9 +158,9 @@ var input = comp => {
 			</Box>
 			{showHistoryButton &&
 			<Tooltip title={tooltips.history}>
-				<Box component={IconButton} onClick={comp.onOpenHistory} sx={sxHistoryButton}>
+				<IconButton onClick={comp.onOpenHistory} style={{position: 'absolute', right: 0, top: -12}}>
 					<Icon>arrow_drop_down</Icon>
-				</Box>
+				</IconButton>
 			</Tooltip>}
 			<Menu
 				anchorEl={comp.input}


### PR DESCRIPTION
Written by Claude.
1. Nav bar updates, including hiding bookmarks when in single cell mode
2. CSS changes in the stats/advanced options in chart view and sample search bar history:

The timing points clearly to the webpack 5 upgrade (2d36d42c) and
  react-hot-loader drop (f8db72d8) from May 2025. Here's the explanation:       
                                                                                
  Why the existing styles broke:
                                                                                
  MUI v4 components (Accordion, etc.) generate their styles via JSS and inject  
  them into the <head> at component mount time (during React rendering). CSS    
  module styles (chart.module.css) are injected at bundle import time — before  
  any React rendering happens. This means MUI component styles always land in
  the <head> after the CSS module styles.

  When two rules have equal specificity, the later one in the document wins. So 
  for any same-specificity conflict, MUI's styles silently override the CSS
  module styles.                                                                
                                                                  
  What changed in May 2025:

  React Hot Loader, when active, would re-inject CSS module styles during hot   
  reloads — accidentally placing them after MUI's styles, so they'd win
  same-specificity battles. With react-hot-loader dropped and webpack 5's       
  cleaner style injection, CSS modules are now injected exactly once, at page
  load, before MUI ever mounts. The pre-existing CSS module rules (which were
  relying on that accidental late-injection behavior) stopped taking effect.

  What the fixes do:

  For each accordion expanded-state rule that MUI was winning:                  
  - Cases where both rules have 2-class specificity (a tie): added !important to
   the CSS module rule to guarantee it wins                                     
  - Cases where a descendant element needs targeting: used :global(.MuiXxx)
  selector syntax to bump CSS module specificity to 3 classes, beating MUI's    
  2-class expanded-state rules without needing !important