### PR TITLE
fixing freeze tooltip bug

### DIFF
--- a/js/views/Tooltip.js
+++ b/js/views/Tooltip.js
@@ -137,7 +137,7 @@ class Tooltip extends PureComponent {
 
 		return (
 			<div>
-				<Box component={Backdrop} open={frozen} sx={{bgcolor: xenaColor.BLACK_12, zIndex: 1200}}/>
+				<Backdrop open={frozen} style={{backgroundColor: xenaColor.BLACK_12, zIndex: 1150}}/>
 				<Box component={Paper} key={sampleID}
 					 className={classNames(compStyles.Tooltip, {[compStyles.frozen]: frozen})}
 					 elevation={0} square sx={sxTooltip}>


### PR DESCRIPTION
Written by Claude  

Summary                                                                       
                                                                                
  - Fixes the freeze tooltip (option-click) feature, which was not dimming the
  screen or blocking user interaction with page elements when frozen.           
                                                                  
  Root cause                                                                    
                                                                  
  <Box component={Backdrop} sx={{zIndex: 1200}}> was silently broken by a MUI v4
   CSS specificity issue. MUI v4's Backdrop component injects its own JSS style
  (zIndex: -1) at component mount time — after Box's sx-generated style is      
  injected — so same-specificity rules cause MUI's zIndex: -1 to win. The
  backdrop ended up hidden behind all page content, making it neither visible
  nor able to block pointer events.

  Fix

  - Replace Box component={Backdrop} sx={{...}} with Backdrop style={{...}}.    
  Inline styles always override JSS class styles, ensuring position: fixed and
  z-index take effect.                                                          
  - Set zIndex: 1150 rather than 1200. This places the backdrop above the
  control bar (AppBar at 1100, now blocked) but below the nav bar (AppBar at    
  1350, still accessible) and below the frozen tooltip panel (CSS z-index 1200,
  still accessible).   